### PR TITLE
issue #29, update travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,17 @@ script:
       cat cppcheck_err.txt
       exit -1
     fi
+
+  #cppcheck flight software psp/fsw, osal/src/bsp, osal/src/os, fsw/cfe-core/src
+  - cppcheck --force --inline-suppr --std=c99 --language=c --error-exitcode=1 --enable=warning,performance,portability,style --suppress=variableScope --inconclusive psp/fsw osal/src/bsp osal/src/os cfe/fsw/cfe-core/src 2>cppcheck_flighterror.txt
+  - |
+    if [[ -s cppcheck_flighterror.txt ]]; then
+      echo "You must fix cppcheck errors before submitting a pull request"
+      echo ""
+      cat cppcheck_flighterror.txt
+      exit -1
+    fi
+ 
   # Prep and build
   - make prep
   - make


### PR DESCRIPTION
**Describe the contribution**
update travis.yml for stricter cppcheck for flight software.

**Testing performed**
1. run scripts with 
```
   #! /bin/bash
   cppcheck --force --inline-suppr --std=c99 --language=c --error-exitcode=1 --enable=warning,performance,portability,style --suppress=variableScope --inconclusive psp/fsw osal/src/bsp osal/src/os cfe/fsw/cfe-core/src 2>cppcheck_flighterror.txt

    if [[ -s cppcheck_flighterror.txt ]]; then
      echo "You must fix cppcheck errors before submitting a pull request"
      echo ""
      cat cppcheck_flighterror.txt
      exit -1
    fi
```
2. verify cppcheck runs.

**System(s) tested on**

 - Hardware
 - Ubuntu 18.04
 - cfe 6.6

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)

Anh Van, NASA Goddard
  - CFE framework
