### PR TITLE
Fixes 43, updates instructions from python2-->3

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The cFS-GroundSystem tool can be used to send commands and receive telemetry (se
        cd tools/cFS-GroundSystem/Subsystems/cmdUtil
        make
        cd ../..
-       python GroundSystem.py
+       python3 GroundSystem.py
 
 3. Select "Start Command System"
 4. Select "Enable Tlm"


### PR DESCRIPTION
Describe the contribution
Fix #43, Updates README file to reflect upgrade from python 2-->3 in GroundSystem.py scripts.

Steps taken to test the contribution:
    Launched GroundSystem.py tool using the updated instruction.

Expected behavior changes:
README.md is now updated to reflect upgrade to python3.

System(s) tested on:
    Oracle VM VirtualBox
    OS: ubuntu-19.10
    Versions: cFE 6.7.6.0, OSAL 5.0.6.0, PSP 1.4.4.0

Contributor Info:
Dan Knutsen
GSFC/NASA
