### PR TITLE
Fix #79, Add sleep after script to avoid truncated log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,3 +124,7 @@ script:
             grep -i 'warn\|err\|fail' cFS_startup.txt
             exit -1
     fi
+
+# After script sleep avoids Job log truncation
+after_script:
+  - sleep 1


### PR DESCRIPTION
**Describe the contribution**
Added after_script sleep to CI
Fix #79 

**Testing performed**
CI - See https://travis-ci.com/github/skliper/cFS/builds/164015394

**Expected behavior changes**
Full job log now available on travis

**System(s) tested on**
 - Hardware: CI
 - OS: Ubuntu 18.04
 - Versions: Master bundle + this commit

**Additional context**
None

**Code contibutions**
The cFS repository is provided to bundle the cFS Framework.  It is utilized for bundling submodules, continuous integration testing, and version management and does not contain any software.  Code contributions should be directed to the appropriate submodule.

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC