### PR TITLE
Move travis CI script into a .sh file

### DIFF
--- a/cfstestscript.sh
+++ b/cfstestscript.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+cp -r cfe/cmake/sample_defs sample_defs
+cp -f /cfs/cfe/cmake/sample_defs/global_build_options.cmake ./sample_defs/global_build_options.cmake
+make SIMULATION=native ENABLE_UNIT_TESTS=false prep
+
+# turn on bash's job control
+set -m
+
+# Start the primary process and put it in the background
+./build/exe/cpu1/core-cpu1 >cFS_startup.txt &
+
+# Start the helper process
+./build/exe/host/cmdUtil --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
+
+./build/build/tools/cFS-GroundSystem/Subsystems/cmdUtil/cmdUtil --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
+
+Executive Services, CFE_ES_CMD, ES No-Op, 0, 0x1806, LE, 127.0.0.1, 1234, CFE_ES_NOOP_CC
+Software Bus, CFE_SB_CMD, SB No-Op, 0, 0x1803, LE, 127.0.0.1, 1234, CFE_SB_NOOP_CC
+Table Services, CFE_TBL_CMD, TBL No-Op, 0, 0x1804, LE, 127.0.0.1, 1234, CFE_TBL_NOOP_CC
+Time Services, CFE_TIME_CMD, Time No-Op, 0, 0x1805, LE, 127.0.0.1, 1234, CFE_TIME_NOOP_CC
+Event Services, CFE_EVS_CMD, EVS No-Op, 0, 0x1801, LE, 127.0.0.1, 1234, CFE_EVS_NOOP_CC
+# the my_helper_process might need to know how to wait on the
+# primary process to start before it does its work and returns
+
+# now we bring the primary process back into the foreground
+# and leave it there
+fg %1

--- a/containers/ReadMe.md
+++ b/containers/ReadMe.md
@@ -1,0 +1,36 @@
+<!-- cFS Containers ReadMe.md -->
+
+## gcc-cmake Containers
+
+The gcc-cmake image can be used to build and run cFS and it's doxygen documentation.
+
+### Building and running the gcc-cmake image
+
+When building the image make sure to give it a name with the `tag` option
+
+```bash
+docker build -t gcc-cmake PATH_TO_DOCKERFILE_DIRECTORY
+```
+
+```bash
+docker run -it --sysctl fs.mqueue.msg_max=3000  -v PATH_TO_CFS_DIRECTORY:/cfs gcc-cmake
+```
+
+## Running and building cFS
+
+The gcc-cmake container is meant for mounting your host's cfs directory but building and testing inside the container.
+Once you launch the container navigate to the cfs directory and run the following
+
+```bash
+cp -r cfe/cmake/sample_defs sample_defs
+cp -r cfe/cmake/Makefile.sample Makefile
+export SIMULATION=native
+make install
+```
+
+The above command sequence will setup cFS to run inside the container by executing the following commands
+
+```bash
+cd build/exe/cpu1
+./core-cpu1
+```

--- a/containers/gcc-cmake/Dockerfile
+++ b/containers/gcc-cmake/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcc
+
+RUN apt-get update && apt-get install -y cmake
+# libgtest-dev libboost-test-dev && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y doxygen


### PR DESCRIPTION
**Describe the contribution**
The current Travis setup is cumbersome to replicate on a local system. 

This collects all the commands and moves them onto a standalone shell file that can be used on multiple systems.

**Testing performed**
Tested on CI

**Expected behavior changes**
Same behavior as current CI

**System(s) tested on**
Travis CI

**Additional context**
This can benefit from a containerized build system using docker.
Might address some of the desires in #76 

In the future it might make sense to separate these into subscripts with "build-exec", "unit-test", and "build-doc" or something like that. Though there is a balance between this approach and using makefiles

**Contributor Info - All information REQUIRED for consideration of pull request**
Gerardo E. Cruz-Ortiz, NASA-GSFC
