### PR TITLE
Fix #88, Only inline empty functions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,7 +11,7 @@ AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Empty
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
+AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterReturnType: None


### PR DESCRIPTION
**Describe the contribution**
Fix #88

**Testing performed**
Ran against related repos, confirmed style update.

**Expected behavior changes**
None - Whitespace

**System(s) tested on**
 - Hardware: cFS Dev Server 3
 - OS: Ubuntu 18.04
 - Versions: Master bundle + this commit.

**Additional context**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC