### PR TITLE
Fix #92 - Update lgtm.yml to exclude Ui files

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -10,6 +10,7 @@ extraction:
       version: "3"
     index:
       include: "tools/cFS-GroundSystem"
+      exclude: "tools/cFS-GroundSystem/**/Ui_*"
   cpp:
     index:
       build_command:

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -10,7 +10,6 @@ extraction:
       version: "3"
     index:
       include: "tools/cFS-GroundSystem"
-      exclude: "tools/cFS-GroundSystem/**/Ui_*"
   cpp:
     index:
       build_command:


### PR DESCRIPTION
**Describe the contribution**
Fixes #92 to exclude files in cFS-GroundSystem with the `Ui_` prefix

**Testing performed**
Steps taken to test the contribution:
Pending lgtm run

**Expected behavior changes**
lgtm analysis should not include `Ui_` files

**Code contibutions**
The cFS repository is provided to bundle the cFS Framework.  It is utilized for bundling submodules, continuous integration testing, and version management and does not contain any software.  Code contributions should be directed to the appropriate submodule.

**Contributor Info - All information REQUIRED for consideration of pull request**
Leor Bleier, NASA GSFC\Code 582
