### PR TITLE
Dockerized End-To-End Tests (Proof of Concept)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Makefile
+build/
+sample_defs/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '2'
+
+services:
+  cfs:
+    build:
+        context: ./
+        dockerfile: ./tools/e2eTests/platforms/Ubuntu/18.04/Dockerfile
+        args:
+          - ENABLE_UNIT_TESTS=false
+          - SIMULATION=native
+          - BUILDTYPE=debug
+          - OMIT_DEPRECATED=true
+    cap_add: 
+      - CAP_SYS_RESOURCE
+    networks:
+      - default
+    depends_on:
+      - gsw
+
+  gsw:
+    build:
+        context: ./
+        dockerfile: ./tools/e2eTests/gsw/Dockerfile
+    networks:
+      - default
+  
+networks:
+  default:
+    internal: true    

--- a/tools/e2eTests/README.md
+++ b/tools/e2eTests/README.md
@@ -1,0 +1,133 @@
+# Core Flight System - Dockerized End-To-End Testing Tool
+
+A tool to perform dockerized end-to-end tests of cFS.
+
+This tool simulates network-based interactions between the cFS executable and a pseudo-ground system software acting as a test runner.
+
+## Getting Started
+
+### Requirements
+
+* Docker 19 or higher
+* Docker Compose compatible with compose file format 2.0 or higher
+
+### Run the test
+
+From the cFS top-level directory, run the following command:
+
+```
+docker-compose up --abort-on-container-exit --exit-code-from gsw
+```
+
+By default, the test runs with the following options:
+
+* Operating System: Ubuntu 18.04
+* Unit tests disabled
+* Simulation: native
+* Build type: debug
+* Deprecated omitted
+
+When the test passes, it exits with a zero exit code. Otherwise, it exits with a non-zero exit code.
+
+Note: `--abort-on-container-exit` makes `cfs` stop when `gsw` (i.e. the test runner) exits, and `--exit-code-from gsw` returns `gsw` exit code (that is: the test status).
+
+### Optional: Customize the cFS Image
+
+The default options to build the images are specified in `docker-compose.yml` (located at the cFS top-level directory), lines 7-12:
+
+```yaml
+dockerfile: ./tools/e2eTests/platforms/Ubuntu/18.04/Dockerfile
+args:
+  - ENABLE_UNIT_TESTS=false
+  - SIMULATION=native
+  - BUILDTYPE=debug
+  - OMIT_DEPRECATED=true
+```
+
+To customize these options:
+
+1. First, make `docker-compose.yml` refer to the relevant `Dockerfile` to specify the expected operating system (cFS `dockerfile` configuration option, line 7):
+
+    ```yaml
+    cfs:
+      build:
+        ...
+        dockerfile: ./tools/e2eTests/platforms/Ubuntu/18.04/Dockerfile
+    ```
+
+    To this end, use one of the following options.
+
+    | Operating System | Path to the corresponding Dockerfile                       |
+    |------------------|--------------------------------------------------------|
+    | Alpine 3         | `./tools/e2eTests/platforms/Alpine/3/Dockerfile`       |
+    | CentOS 7         | `./tools/e2eTests/platforms/CentOS/7/Dockerfile`       |
+    | Ubuntu 18.04     | `./tools/e2eTests/platforms/Ubuntu/18.04/Dockerfile`   |
+    | Ubuntu 20.04     | `./tools/e2eTests/platforms/Ubuntu/20.04/Dockerfile`   |
+
+2. Second, build the relevant cFS Docker image (tagged `cfs`) by passing the expected option(s) using `--build-arg`:
+
+   ```
+    docker-compose build --no-cache --build-arg <key1=value1> [--build-arg <key2=value2> ...] cfs
+    ```
+
+	For instance, to enable unit tests and set the build type to release:
+
+    ```
+    docker-compose build --no-cache --build-arg ENABLE_UNIT_TESTS=true --build-arg BUILDTYPE=release cfs
+    ```
+    
+3. Finally, run the test:
+	
+	```
+	docker-compose up --abort-on-container-exit --exit-code-from gsw
+	```
+
+## Alternative: Direct Use of cFS Containers
+
+It is possible to build cFS images and run the corresponding containers independently of the Docker Compose solution.
+
+### Build the cFS image
+
+To build a cFS image, run the following command from the cFS top-level directory (indeed, the working directory for the build context is expected to be the root of the cFS directory):
+
+```
+docker build \
+-t <tag of the image> \
+-f <path to the relevant Dockerfile> \
+--build-arg ENABLE_UNIT_TESTS=false \
+--build-arg SIMULATION=native \
+--build-arg BUILDTYPE=<build type> \
+--build-arg OMIT_DEPRECATED=<boolean value> .
+```
+
+Example:
+
+```
+docker build \
+-t cfs_ubuntu18 \
+-f ./tools/e2eTests/platforms/Ubuntu/18.04/Dockerfile \
+--build-arg ENABLE_UNIT_TESTS=false \
+--build-arg SIMULATION=native \
+--build-arg BUILDTYPE=debug \
+--build-arg OMIT_DEPRECATED=true .
+```
+
+Note that unit tests should preferably be disabled to decouple unit testing from end-to-end testing.
+
+### Run the cFS Container
+
+One the cFS image has been built, it can be run with the following command:
+
+```
+docker run --cap-add CAP_SYS_RESOURCE --net=host <tag of the image>
+```
+
+Example:
+
+```
+docker run --cap-add CAP_SYS_RESOURCE --net=host cfs_ubuntu18
+```
+
+The cFS ground system can then interact with the containerized cFS executable on localhost (on Linux and Windows hosts).
+
+Note: `--cap-add CAP_SYS_RESOURCE` is required for queues to be handled properly. Failing to add the `CAP_SYS_RESOURCE` capability would prematurely terminate the execution of the cFS container.

--- a/tools/e2eTests/gsw/Dockerfile
+++ b/tools/e2eTests/gsw/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.7.7-alpine3.11 
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /test_runner
+
+COPY tools/e2eTests/gsw/gsw.py gsw.py
+
+RUN chmod +x gsw.py
+
+ENTRYPOINT [ "./gsw.py" ]

--- a/tools/e2eTests/gsw/gsw.py
+++ b/tools/e2eTests/gsw/gsw.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+
+"""
+Proof of concept:
+Pseudo-GSW to perform a simple end-to-end test of a dockerized cFS
+"""
+
+from enum import IntEnum
+import socket
+import time
+import sys
+
+class Test_status(IntEnum):
+    PASS = 0
+    FAIL = 1
+
+SAMPLE_APP_NOOP_PACKET = bytearray([
+        0x18, 0x82, 0xC0, 0x00, 0x00,
+        0x01, 0x00, 0x00
+    ])
+
+ENABLE_TELEMETRY_PACKET_TEMPLATE = bytearray([
+        0x18, 0x80, 0xC0, 0x00, 0x00,
+        0x12, 0x06, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00
+    ])
+
+CFS_PORT = 1234
+GSW_PORT = 1235
+
+try:
+    # Host name shall match the cFS service name in docker-compose.yml
+    CFS_IP = socket.gethostbyname('cfs')
+except:
+    print('Error: cFS IP is unknown')
+    exit(1)
+
+try:
+    # Host name shall match the GSW service name in docker-compose.yml
+    GSW_IP = socket.gethostbyname('gsw') 
+except:
+    print('Error: GSW IP is unknown')
+    exit(1)
+
+
+def craft_telemetry_packet() -> bytearray:
+    """
+    Craft telemetry packet from enable telemetry packet template
+    """
+
+    packet = ENABLE_TELEMETRY_PACKET_TEMPLATE
+
+    i = 8 # IP starts at index 8
+    for c in GSW_IP:
+       packet[i] = int(hex(ord(c)), 16)
+       i += 1
+
+    return packet
+
+def enable_telemetry() -> bool:
+    """
+    Try to enable the telemetry
+    """
+
+    print('Enable telemetry (cFS IP: ' + CFS_IP + ', GSW IP: ' + GSW_IP + ')')
+
+    testSocket.sendto(craft_telemetry_packet(), (CFS_IP, CFS_PORT))
+
+    if telemetry_contains("telemetry output enabled for IP {}".format(GSW_IP), 10):
+        return True 
+        
+    return False
+
+def telemetry_contains(expected_event, max_attempts) -> bool:
+    """
+    Check whether the telemetry contains an expected event or not
+    """
+
+    print ('Listening to cFS telemetry (expected event: "' + expected_event + '")')    
+
+    attempts = 0
+    while attempts < max_attempts:
+        try:
+            datagram, _ = testSocket.recvfrom(4096)
+            actual_event = ''.join(map(chr, datagram))
+            #print(attempts, ': ', actual_event)
+            if expected_event in actual_event:
+                return True
+        except:
+            pass
+
+        attempts += 1
+        time.sleep(1)
+
+    return False 
+
+def assert_sample_app_noop():
+    """
+    Send a NOOP command (SAMPLE_APP) and ensure that it is acknowledged by cFS
+    """
+    
+    print ('SAMPLE_APP: Sending NOOP command')
+    testSocket.sendto(SAMPLE_APP_NOOP_PACKET, (CFS_IP, CFS_PORT))
+
+    if telemetry_contains('SAMPLE: NOOP command', 10):
+        return Test_status.PASS
+    
+    return Test_status.FAIL
+
+
+#
+# Main
+#
+if __name__ == "__main__":
+
+    # Setup
+    time.sleep(5) # Warming up
+    testSocket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    testSocket.bind(('', GSW_PORT))
+    testSocket.settimeout(.1)
+
+    # Test - SAMPLE_APP NOOP command is acknowledged by cFS
+    if enable_telemetry():
+        test_status = assert_sample_app_noop()
+
+    # Teardown
+    testSocket.close()
+
+    # Exit
+    print('Test status: ', end = '')
+    if test_status == Test_status.PASS:
+        print('PASS')
+        sys.exit(0)
+    else:
+        print('FAIL')
+        sys.exit(1)

--- a/tools/e2eTests/platforms/Alpine/3/Dockerfile
+++ b/tools/e2eTests/platforms/Alpine/3/Dockerfile
@@ -1,0 +1,53 @@
+# Warning: This image is currently not operational 
+
+FROM alpine:3.11 AS builder
+
+ARG ENABLE_UNIT_TESTS
+ENV ENABLE_UNIT_TESTS=${ENABLE_UNIT_TESTS} 
+
+ARG SIMULATION
+ENV SIMULATION=${SIMULATION}
+
+ARG BUILDTYPE
+ENV BUILDTYPE=${BUILDTYPE}
+
+ARG OMIT_DEPRECATED
+ENV OMIT_DEPRECATED=${OMIT_DEPRECATED}
+
+RUN echo http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
+
+RUN set -ex &&                          \
+    apk add --update --no-cache         \
+        make=4.2.1-r2                   \
+        cmake=3.15.5-r0                 \
+        git=2.24.3-r0                   \
+        gcc=9.2.0-r4                    \
+        g++=9.2.0-r4
+
+RUN if [ "${ENABLE_UNIT_TESTS}" = true ]; \
+    then { echo http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
+    apk add --update --no-cache lcov=1.14-r0; } fi
+
+WORKDIR /cFS
+
+COPY . . 
+
+RUN git submodule init \
+    && git submodule update \
+    && cp cfe/cmake/Makefile.sample Makefile \
+    && cp -r cfe/cmake/sample_defs .
+
+RUN make prep
+RUN make
+RUN make install
+RUN if [ "${ENABLE_UNIT_TESTS}" = true ]; then { ( make test | grep 'Failed' ) && ( make lcov | grep '%' ); } fi
+RUN if [ "${ENABLE_UNIT_TESTS}" = true ]; then { cat ./build/native/Testing/Temporary/LastTest.log | grep 'FAIL' | grep -v 'FAIL::0'; } fi
+
+
+FROM alpine:3.11
+
+COPY --from=builder /cFS/build /cFS/build
+
+WORKDIR /cFS/build/exe/cpu1
+
+CMD [ "./core-cpu1" ]

--- a/tools/e2eTests/platforms/CentOS/7/Dockerfile
+++ b/tools/e2eTests/platforms/CentOS/7/Dockerfile
@@ -1,0 +1,51 @@
+FROM centos:7 AS builder
+
+ARG LCOV_VERSION=1.13-1.el7
+
+ARG ENABLE_UNIT_TESTS
+ENV ENABLE_UNIT_TESTS=${ENABLE_UNIT_TESTS} 
+
+ARG SIMULATION
+ENV SIMULATION=${SIMULATION}
+
+ARG BUILDTYPE
+ENV BUILDTYPE=${BUILDTYPE}
+
+ARG OMIT_DEPRECATED
+ENV OMIT_DEPRECATED=${OMIT_DEPRECATED}
+
+RUN yum -y -q update                    \
+    && yum -y install                   \
+        git-1.8.3.1-21.el7_7.x86_64     \
+        cmake-2.8.12.2-2.el7.x86_64     \
+        make-3.82-24.el7.x86_64         \
+        gcc-4.8.5-39.el7.x86_64
+
+RUN if [ "${ENABLE_UNIT_TESTS}" = true ]; \
+    then { curl https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/l/lcov-${LCOV_VERSION}.noarch.rpm \
+           -o lcov-${LCOV_VERSION}.noarch.rpm \
+           && yum -y install lcov-${LCOV_VERSION}.noarch.rpm; } fi
+
+WORKDIR /cFS
+
+COPY . .
+
+RUN git submodule init \
+    && git submodule update \
+    && cp cfe/cmake/Makefile.sample Makefile \
+    && cp -r cfe/cmake/sample_defs .
+
+RUN make prep
+RUN make
+RUN make install
+RUN if [ "${ENABLE_UNIT_TESTS}" = true ]; then { ( make test | grep 'Failed' ) && ( make lcov | grep '%' ); } fi
+RUN if [ "${ENABLE_UNIT_TESTS}" = true ]; then { cat ./build/native/Testing/Temporary/LastTest.log | grep 'FAIL' | grep -v 'FAIL::0'; } fi
+
+
+FROM centos:7
+
+COPY --from=builder /cFS/build /cFS/build
+
+WORKDIR /cFS/build/exe/cpu1
+
+CMD [ "./core-cpu1" ]

--- a/tools/e2eTests/platforms/Ubuntu/18.04/Dockerfile
+++ b/tools/e2eTests/platforms/Ubuntu/18.04/Dockerfile
@@ -1,0 +1,54 @@
+FROM ubuntu:18.04 AS builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+ARG LCOV_VERSION=1.13-3
+
+ARG ENABLE_UNIT_TESTS 
+ENV ENABLE_UNIT_TESTS=${ENABLE_UNIT_TESTS} 
+
+ARG SIMULATION
+ENV SIMULATION=${SIMULATION}
+
+ARG BUILDTYPE
+ENV BUILDTYPE=${BUILDTYPE}
+
+ARG OMIT_DEPRECATED
+ENV OMIT_DEPRECATED=${OMIT_DEPRECATED}
+
+RUN apt-get -qy update                              \
+    && apt-get -y install --no-install-recommends   \
+        ca-certificates=20190110~18.04.1            \
+        git=1:2.17.1-1ubuntu0.7                     \
+        cmake=3.10.2-1ubuntu2.18.04.1               \
+        make=4.1-9.1ubuntu1                         \
+        gcc=4:7.4.0-1ubuntu2.3                      \
+        g++=4:7.4.0-1ubuntu2.3                      \
+    && rm -rf /var/lib/apt/lists/*                
+
+# Optional: Install lcov
+RUN if [ "${ENABLE_UNIT_TESTS}" = true ]; then { apt-get -qy update && apt-get -y install lcov=${LCOV_VERSION}; } fi
+
+WORKDIR /cFS
+
+COPY . .
+
+RUN git submodule init \
+    && git submodule update \
+    && cp cfe/cmake/Makefile.sample Makefile \
+    && cp -r cfe/cmake/sample_defs .
+
+RUN make prep
+RUN make
+RUN make install
+RUN if [ "${ENABLE_UNIT_TESTS}" = true ]; then { ( make test | grep 'Failed' ) && ( make lcov | grep '%' ); } fi
+RUN if [ "${ENABLE_UNIT_TESTS}" = true ]; then { cat ./build/native/Testing/Temporary/LastTest.log | grep 'FAIL' | grep -v 'FAIL::0'; } fi
+
+
+FROM ubuntu:18.04
+
+COPY --from=builder /cFS/build /cFS/build
+
+WORKDIR /cFS/build/exe/cpu1
+
+ENTRYPOINT [ "./core-cpu1" ]

--- a/tools/e2eTests/platforms/Ubuntu/20.04/Dockerfile
+++ b/tools/e2eTests/platforms/Ubuntu/20.04/Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:20.04 AS builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+ARG LCOV_VERSION=1.14-2
+
+ARG ENABLE_UNIT_TESTS
+ENV ENABLE_UNIT_TESTS=${ENABLE_UNIT_TESTS} 
+
+ARG SIMULATION
+ENV SIMULATION=${SIMULATION}
+
+ARG BUILDTYPE
+ENV BUILDTYPE=${BUILDTYPE}
+
+ARG OMIT_DEPRECATED
+ENV OMIT_DEPRECATED=${OMIT_DEPRECATED}
+
+RUN apt-get -qy update                        \
+    && apt-get -y install                     \
+        ca-certificates=20190110ubuntu1.1     \
+        git=1:2.25.1-1ubuntu3                 \
+        cmake=3.16.3-1ubuntu1                 \
+        make=4.2.1-1.2                        \
+        gcc=4:9.3.0-1ubuntu2                  \
+        g++=4:9.3.0-1ubuntu2                  \
+    && rm -rf /var/lib/apt/lists/*          
+
+# Optional: Install lcov
+RUN if [ "${ENABLE_UNIT_TESTS}" = true ]; \
+    then { apt-get update && \
+    apt-get -y install software-properties-common=0.98.9 && \
+    add-apt-repository ppa:ubuntu-toolchain-r/test && \
+    apt-get -qy update && \
+    apt-get -y install lcov=${LCOV_VERSION}; } fi                    
+
+WORKDIR /cFS
+
+COPY . .
+
+RUN git submodule init \
+    && git submodule update \
+    && cp cfe/cmake/Makefile.sample Makefile \
+    && cp -r cfe/cmake/sample_defs .
+
+RUN make prep
+RUN make
+RUN make install
+RUN if [ "${ENABLE_UNIT_TESTS}" = true ]; then { ( make test | grep 'Failed' ) && ( make lcov | grep '%' ); } fi
+RUN if [ "${ENABLE_UNIT_TESTS}" = true ]; then { cat ./build/native/Testing/Temporary/LastTest.log | grep 'FAIL' | grep -v 'FAIL::0'; } fi
+
+
+FROM ubuntu:20.04
+
+COPY --from=builder /cFS/build /cFS/build
+
+WORKDIR /cFS/build/exe/cpu1
+
+ENTRYPOINT [ "./core-cpu1" ]


### PR DESCRIPTION
# Describe the contribution

A tool to perform dockerized end-to-end tests of cFS.

This tool simulates network-based interactions between containerized cFS executables and a pseudo-ground system software acting as a test runner.

(General context: https://github.com/nasa/cFS/issues/56)

## Quick Overview

The tool makes a containerized cFS executable (`cfs` service) and a test runner (`gsw` service) interact. The following screen captures illustrate this mechanism by comparing a passing test with a failing one.

<img width="759" alt="Overview" src="https://user-images.githubusercontent.com/63288227/83953426-a4887100-a840-11ea-8ef1-87749b594aeb.png">

1. `gsw` service: the test runner
2. `cfs` service: the system under test (i.e. a containerized cFS executable)
3. Zero exit code (the test passed)
4. Error voluntarily triggered for demonstration purposes: here, the `NOOP` command does not emit the expected event
5. Non-zero exit code (the test failed)

## Quick Start

### Requirements

* Docker 19 or higher
* Docker Compose compatible with compose file format 2.0 or higher

### Usage

From the cFS top-level directory, run the following command:

`docker-compose up --abort-on-container-exit --exit-code-from gsw`

When executed for the first time, this command builds the cFS with the options set in `docker-compose.yml` (by default: Ubuntu 18.04, unit tests disabled, simulation native, debug build, and deprecated omitted) as well as a pseudo-ground system software that attempts to enable the telemetry and, if successful, runs a simple assertion.

The default build-time options can be found (and, if needed, modified) in `docker-compose.yml` (lines 7-12):

```yaml
dockerfile: ./tools/e2eTests/platforms/Ubuntu/18.04/Dockerfile
args:
  - ENABLE_UNIT_TESTS=false
  - SIMULATION=native
  - BUILDTYPE=debug
  - OMIT_DEPRECATED=true
```

For more details, please refer to the `README` file located in `tools/e2eTests` subdirectory.

## Goal

The purpose of this working proof of concept is to demonstrate the potential as well as the limitations of using Docker to perform end-to-end tests.

This approach has several advantages.

First, it aims at enabling the future incorporation of end-to-end tests in the continuous integration process, automatically ensuring that the executable is working as expected in the scope of these tests. In this regard, it should be noted that Travis can run Docker Compose commands (see: <https://docs.travis-ci.com/user/docker/#using-docker-compose>).

Second, it allows for more granular control of the testing environment by pinning the operating systems and the required dependencies to a specific version. Therefore, it makes the tests highly reproducible. It follows that the versions of the packages are explicitly specified in all cFS Dockerfiles. For instance (`tools/e2eTests/platforms/Ubuntu/18.04/Dockerfile`, lines 19-27):

```
RUN apt-get -qy update                              \
    && apt-get -y install --no-install-recommends   \
        ca-certificates=20190110~18.04.1            \
        git=1:2.17.1-1ubuntu0.7                     \
        cmake=3.10.2-1ubuntu2.18.04.1               \
        make=4.1-9.1ubuntu1                         \
        gcc=4:7.4.0-1ubuntu2.3                      \
        g++=4:7.4.0-1ubuntu2.3                      \
    && rm -rf /var/lib/apt/lists/*
```

Third, it facilitates the compilation of cFS executables using different combinations of built-time options. In other words, it potentially permits the automatic generation of matrixed cFS executables.

## Limitations

The purpose of this pull request, which introduces a working proof of concept, is not per se to provide a _complete_ end-to-end testing solution. As a consequence, this tool is not yet integrated into the existing Travis configuration, and the test runner performs a simple assertion.

This contribution is also limited by the technical characteristics of Docker. In particular:
* Broadly speaking, Docker does not natively and/or straightforwardly support "non-standard" operating systems (e.g. RTOS). That explains why, for instance (and unfortunately), VxWorks is presently not supported by this solution. Alternative or complementary approaches will be needed to extend automated end-to-end to other platforms. 
* Unit tests systematically fail when the cFS images are being built (see below, *Additional context*). This is one of the reasons why they are disabled by default.

It should also be noted that an Alpine image is included (`./tools/e2eTests/platforms/Alpine/3/Dockerfile`) but is currently not operational, mainly because of the following error: `/usr/include/sys/signal.h:1:2: error: #warning redirecting incorrect #include <sys/signal.h> to <signal.h> [-Werror=cpp]` (see: <https://github.com/nasa/osal/issues/438#issue-607934390>). I have decided to keep it because it is conceivable that it becomes operational in the future.

# Testing performed

In the context of this proof of context, a simple flow is tested by the `gsw` test runner (`tools/e2eTests/gsw/gsw.py`):

* Try to enable the telemetry
* If the telemetry cannot be enabled, the test fails
* Otherwise, send a `NOOP` command (for the SAMPLE app) packet to the cFS
* If a `SAMPLE: NOOP command` event appears in the telemetry message sent by the cFS, the test passes
* Otherwise, the test fails

# Expected behavior changes

This contribution does not modify the existing code. Therefore, no behavior changes are expected.

# System(s) tested on

## Hosts

**Ubuntu**

* Ubuntu 18.04
* VirtualBox 6.0
* Docker 19.03.6
* Docker-compose 1.17.1

**macOS**

* iMac Retina 4K, 2019
* macOS 10.15.5
* Docker 19.03.8
* Docker-compose 1.25.5

## Docker

* Alpine 3 (currently not operational)
* CentOS 7
* Ubuntu 18.04, and 20.04

# Additional context

## Components

The tool consists of:

* Multiple Dockerfiles (one for each version of an operating system) to compile and run the cFS
* A Dockerfile to build and run a pseudo-GSW container to test the cFS executable files
* A `docker-compose.yml` file to make them interact. This Docker Compose file makes reference to two services: `cfs` (the system under test) and `gsw` (the test runner).

**cFS Dockerfiles - `cfs` service**

The cFS Dockerfiles have a multistage structure. The first stage builds the `core-cpu1` executable file. The second one corresponds to the runtime environment for this executable.

**Pseudo-GSW (test runner) - `gsw` service**

The pseudo-GSW is a Python program, running in its own container, that, at this stage, performs a simple assertion and returns a zero (success) or non-zero (failure) exit code.

It is a proof of concept which, obviously, and if the present proposal is accepted, will have to be reworked and replaced by a more robust test runner.

**cFS<>GSW interactions**

`cfs` and `gsw` services are interacting on their own internal network managed by Docker Compose (`docker-compose.yml`, lines 27-29):

```yaml
networks:
  default:
    internal: true  
```

Their IPs are dynamic. In order for `gsw` to get `cfs` IP as well as its own, it uses the names of the corresponding Docker Compose services, benefiting therefore from the Docker DNS lookup feature (`tools/e2eTests/gsw/gsw.py`, lines 35 and 42):

```python
CFS_IP = socket.gethostbyname('cfs')
. . .
GSW_IP = socket.gethostbyname('gsw')
```

## Unit Tests Failures

As evoked above, the unit tests fail during the building stage (i.e. at compile-time, but not at runtime). This is due to a Docker limitation vis à vis POSIX message queues that is explainable by the fact that Docker disables, among other things, the `CAP_SYS_RESOURCE` Linux capability. When a cFS image is being built with unit tests enabled, the unit tests that fail are `osal-core-test` (`OS_QueueCreate`, `OS_QueueDelete`, `OS_QueueGetIdByName` and `OS_QueueGetInfo`) as well as `queue-timeout-test`.

There are four possible approaches to overcome this issue:

1. Disable unit tests at build time. In the context of continuous integration testing, that would make sense as the unit tests would continue to be performed in a preliminary and separate job.
2. Allow unit tests to fail at build time.
3. Modify the unit tests to make them fully compatible with Docker. Not necessarily desirable as it would affect the characteristics of the system under test.
4. Run unit tests at runtime. Indeed, the solution requires the Docker containers to run with capability `CAP_SYS_RESOURCE` (It should be noted that `privileged: true` would have the same effect but with a more extensive scope) (`docker-compose.yml`, lines 13-14):

    ```yaml
    cap_add: 
      - CAP_SYS_RESOURCE
    ```

    Such an approach would however blur the line between unit testing and end-to-end testing. For this reason, I would mostly recommend against it.

## Suggestions for Future Improvements

* A more complete and robust test runner
* Travis integration
* A solution to generate matrixed cFS executables and compare their respective test results

# Third party code
None

# Contributor Info - All information REQUIRED for consideration of pull request
Guillaume Lethuillier
Personal, individual CLA submitted