### PR TITLE
Fix #68, Add a reference to skeleton_app in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The following list is user submitted, and not CCB controlled.  They are released
     - SCA: Stored Command Absolute application at https://github.com/nasa/SCA
     - SCH: Scheduler application at https://github.com/nasa/SCH
     - TO: Telemetry Output application at https://github.com/nasa/CFS_TO
+    - Skeleton App: A bare-bones application to which you can add your business logic at https://github.com/nasa/skeleton_app 
   - Other Interfaces
     - SIL: Simulink Interface Layer at https://github.com/nasa/SIL
     - ECI: External Code Interface at https://github.com/nasa/ECI


### PR DESCRIPTION
**Describe the contribution**
Added a reference to the skeleton_app (https://github.com/nasa/skeleton_app) in the cFS bundle's README.md.

In this reference I provided a short description of the skeleton app with a link to its repository.
This reference was placed under the "Other cFS related elements/tools/apps/distributions" section, under the "Other Apps" category.

Resolves: #68 

**Testing performed**
N/A

**Expected behavior changes**
N/A

**System(s) tested on**
N/A

**Additional context**
This is a simple documentation enhancement.

**Code contibutions**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Contribution by: Jandlyn Bentley, NASA GSFC
