### PR TITLE
Fix #116, Add UT failures to CI log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,14 @@ script:
   - make install
   # Run unit tests and generate coverage results
   - make test
+  - |
+    if [[ -s build/native/Testing/Temporary/LastTestsFailed.log ]]; then
+      echo "You must fix unit test errors before submitting a pull request"
+      echo ""
+      cat build/native/Testing/Temporary/LastTestsFailed.log
+      grep "\[ FAIL\]" build/native/Testing/Temporary/LastTest.log
+      exit -1
+    fi
   - make lcov
   # Eventually check/enforce minimum coverage
   # Make documentation


### PR DESCRIPTION
**Describe the contribution**
Fix #116 
Failure now reported and test stops:
```
99% tests passed, 1 tests failed out of 73
Total Test time (real) = 145.89 sec
The following tests FAILED:
	 52 - network-api-test (Failed)
Errors while running CTest
Makefile:138: recipe for target 'test' failed
make: *** [test] Error 8
The command "make test" exited with 2.
$ if [[ -s build/native/Testing/Temporary/LastTestsFailed.log ]]; then
  echo "You must fix unit test errors before submitting a pull request"
  echo ""
  cat build/native/Testing/Temporary/LastTestsFailed.log
  grep "\[ FAIL\]" build/native/Testing/Temporary/LastTest.log
  exit -1
fi
You must fix unit test errors before submitting a pull request
52:network-api-test
[ FAIL] 02.014 network-api-test.c:375 - OS_SocketAccept() (0) == OS_SUCCESS
```

**Testing performed**
Ran with failure (and without), see output above.

**Expected behavior changes**
Just reports failure in ci log

**System(s) tested on**
 - CI with current bundle

**Additional context**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC