### PR TITLE
Fix #92, LGTM exclude generated files

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -4,13 +4,16 @@ queries:
 - exclude: "cpp/long-switch"
 - exclude: "cpp/trivial-switch"
 
+path_classifiers:
+  generated:
+    - "**/Ui_*"
+
 extraction:
   python:
     python_setup:
       version: "3"
     index:
       include: "tools/cFS-GroundSystem"
-      exclude: "tools/cFS-GroundSystem/**/Ui_*"
   cpp:
     index:
       build_command:


### PR DESCRIPTION
**Describe the contribution**
Fix #92 - Exclude generated Ui_* python files from LGTM analysis (2nd try, #94 didn't work)

**Testing performed**
Submit yml script on LGTM and it still functioned, but doesn't provide enough information to tell if the exclusion worked.  Requires an actual LGTM run.

**Expected behavior changes**
Exclude Ui*.py files from issue reporting

**System(s) tested on**
N/A

**Additional context**
#94 was the first attempt, didn't work.

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC