### PR TITLE
Fix #161, Migrate CI to GitHub actions

### DIFF
--- a/.github/workflows/build-cfs-deprecated.yml
+++ b/.github/workflows/build-cfs-deprecated.yml
@@ -1,0 +1,141 @@
+name: "[Deprecated] Build, Test, and Run"
+
+# Run this workflow every time a new commit pushed to your repository
+on: push
+
+env:
+  SIMULATION: native
+  ENABLE_UNIT_TESTS: true
+  OMIT_DEPRECATED: false
+
+jobs:
+
+  # Set the job key. The key is displayed as the job name
+  # when a job name is not provided
+
+  build-cfs:
+    name: Build
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        buildtype: [debug, release]
+
+    # Set the type of machine to run on
+    env:
+      BUILDTYPE: ${{ matrix.buildtype }}
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      # Setup the build system
+      - name: Copy Files
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make Prep
+        run: make prep
+
+      - name: Make
+        run: make
+
+  test-cfs:
+    name: Test
+    needs: build-cfs
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        buildtype: [debug, release]
+
+    # Set the type of machine to run on
+    env:
+      BUILDTYPE: ${{ matrix.buildtype }}
+
+    steps:
+      - name: Install Dependencies
+        run: sudo apt-get install lcov -y
+
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      # Setup the build system
+      - name: Copy Files
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make
+        run: make
+
+      - name: Run Tests
+        run: make test
+
+      - name: Check Coverage
+        run: make lcov
+
+  run-cfs:
+    name: Run
+    needs: build-cfs
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        buildtype: [debug, release]
+
+    # Set the type of machine to run on
+    env:
+      BUILDTYPE: ${{ matrix.buildtype }}
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      # Setup the build system
+      - name: Copy sample_defs
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make Install
+        run: make install
+
+      - name: List cpu1
+        run: ls build/exe/cpu1/
+
+      - name: Run cFS
+        run: |
+          ./core-cpu1 > cFS_startup_cpu1.txt &
+          sleep 30
+          ../host/cmdUtil --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
+        working-directory: ./build/exe/cpu1/
+
+      - name: Archive cFS Startup Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: cFS-startup-log-deprecated-false-${{ matrix.buildtype }}
+          path: ./build/exe/cpu1/cFS_startup_cpu1.txt
+
+      - name: Check for cFS Warnings
+        run: |
+          if [[ -n $(grep -i "warn\|err\|fail" cFS_startup_cpu1.txt) ]]; then
+                  echo "Must resolve warn|err|fail in cFS startup before submitting a pull request"
+                  echo ""
+                  grep -i 'warn\|err\|fail' cFS_startup_cpu1.txt
+                  exit -1
+          fi
+        working-directory: ./build/exe/cpu1/

--- a/.github/workflows/build-cfs.yml
+++ b/.github/workflows/build-cfs.yml
@@ -1,0 +1,141 @@
+name: Build, Test, and Run [OMIT_DEPRECATED=true]
+
+# Run this workflow every time a new commit pushed to your repository
+on: push
+
+env:
+  SIMULATION: native
+  ENABLE_UNIT_TESTS: true
+  OMIT_DEPRECATED: true
+
+jobs:
+
+  # Set the job key. The key is displayed as the job name
+  # when a job name is not provided
+
+  build-cfs:
+    name: Build
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        buildtype: [debug, release]
+
+    # Set the type of machine to run on
+    env:
+      BUILDTYPE: ${{ matrix.buildtype }}
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      # Setup the build system
+      - name: Copy Files
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make Prep
+        run: make prep
+
+      - name: Make
+        run: make
+
+  test-cfs:
+    name: Test
+    needs: build-cfs
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        buildtype: [debug, release]
+
+    # Set the type of machine to run on
+    env:
+      BUILDTYPE: ${{ matrix.buildtype }}
+
+    steps:
+      - name: Install Dependencies
+        run: sudo apt-get install lcov -y
+
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      # Setup the build system
+      - name: Copy Files
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make
+        run: make
+
+      - name: Run Tests
+        run: make test
+
+      - name: Check Coverage
+        run: make lcov
+
+  run-cfs:
+    name: Run
+    needs: build-cfs
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        buildtype: [debug, release]
+
+    # Set the type of machine to run on
+    env:
+      BUILDTYPE: ${{ matrix.buildtype }}
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      # Setup the build system
+      - name: Copy sample_defs
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make Install
+        run: make install
+
+      - name: List cpu1
+        run: ls build/exe/cpu1/
+
+      - name: Run cFS
+        run: |
+          ./core-cpu1 > cFS_startup_cpu1.txt &
+          sleep 30
+          ../host/cmdUtil --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
+        working-directory: ./build/exe/cpu1/
+
+      - name: Archive cFS Startup Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: cFS-startup-log-deprecate-true-${{ matrix.buildtype }}
+          path: ./build/exe/cpu1/cFS_startup_cpu1.txt
+
+      - name: Check for cFS Warnings
+        run: |
+          if [[ -n $(grep -i "warn\|err\|fail" cFS_startup_cpu1.txt) ]]; then
+                  echo "Must resolve warn|err|fail in cFS startup before submitting a pull request"
+                  echo ""
+                  grep -i 'warn\|err\|fail' cFS_startup_cpu1.txt
+                  exit -1
+          fi
+        working-directory: ./build/exe/cpu1/

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -1,0 +1,165 @@
+name: Documentation and Guides
+
+# Run this workflow every time a new commit pushed to your repository
+on: push
+
+env:
+  SIMULATION: native
+
+jobs:
+
+  build-docs:
+    # Name the Job
+    name: cFE Documentation
+    # Set the type of machine to run on
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Install Dependencies
+        run: sudo apt-get install doxygen graphviz -y
+
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      # Setup the build system
+      - name: Copy Files
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make Prep
+        run: make prep
+
+      - name: Build Docs
+        run: |
+          make doc > make_doc_stdout.txt 2> make_doc_stderr.txt
+
+      - name: Archive Users Guide Build Logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: cFS Docs Artifacts
+          path: |
+            make_doc_stdout.txt
+            make_doc_stderr.txt
+
+      - name: Error Check
+        run: |
+          if [[ -s make_doc_stderr.txt ]]; then
+            cat make_doc_stderr.txt
+            exit -1
+          fi
+
+  build-usersguide:
+    # Name the Job
+    name: Users Guide
+    # Set the type of machine to run on
+    runs-on: ubuntu-18.04
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      # Setup the build system
+      - name: Copy Files
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make Prep
+        run: make prep
+
+      - name: Install Dependencies
+        run: sudo apt-get install doxygen graphviz -y
+
+      - name: Build Usersguide
+        run: |
+          make usersguide > make_usersguide_stdout.txt 2> make_usersguide_stderr.txt
+          mv build/doc/warnings.log usersguide_warnings.log
+
+      - name: Archive Users Guide Build Logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: Users Guide Artifacts
+          path: |
+            make_usersguide_stdout.txt
+            make_usersguide_stderr.txt
+            usersguide_warnings.log
+
+
+      - name: Error Check
+        run: |
+          if [[ -s make_usersguide_stderr.txt ]]; then
+            cat make_usersguide_stderr.txt
+            exit -1
+          fi
+
+      - name: Warning Check
+        run: |
+          if [[ -s build/doc/warnings.log ]]; then
+            cat build/doc/warnings.log
+            exit -1
+          fi
+
+  build-osalguide:
+    # Name the Job
+    name: Osal Guide
+    # Set the type of machine to run on
+    runs-on: ubuntu-18.04
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      # Setup the build system
+      - name: Copy Files
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make Prep
+        run: make prep
+
+      - name: Install Dependencies
+        run: sudo apt-get install doxygen graphviz -y
+
+      - name: Build OSAL Guide
+        run: |
+          make osalguide > make_osalguide_stdout.txt 2> make_osalguide_stderr.txt
+          mv build/doc/warnings.log osalguide_warnings.log
+
+
+      - name: Archive Osal Guide Build Logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: OSAL Guide Artifacts
+          path: |
+            make_osalguide_stdout.txt
+            make_osalguide_stderr.txt
+            osalguide_warnings.log
+
+
+      - name: Error Check
+        run: |
+          if [[ -s make_osalguide_stderr.txt ]]; then
+            cat make_osalguide_stderr.txt
+            exit -1
+          fi
+
+      - name: Warning Check
+        run: |
+          if [[ -s build/doc/warnings.log ]]; then
+            cat build/doc/warnings.log
+            exit -1
+          fi


### PR DESCRIPTION
**Describe the contribution**
Fix #161, Add a github actions workflow...

Add a github actions workflow to replace our travis CI

Create three separate workflows based on the .travis.yml file

The build-cfs and build-cfs-deprecated workflows differ only by the OMIT_DEPRECATED flag status.

The build-documentation workflow only builds the doxygen docs.


See examples: <https://github.com/astrogeco/cfs/actions>

**Testing performed**
Ran with current integration candidate

**Expected behavior changes**
Tests run on pull requests and new branches. 

**System(s) tested on**
Ubuntu 18.04

**Additional context**
None

**Code contibutions**
The cFS repository is provided to bundle the cFS Framework.  It is utilized for bundling submodules, continuous integration testing, and version management and does not contain any software.  Code contributions should be directed to the appropriate submodule.

**Contributor Info - All information REQUIRED for consideration of pull request**
@astrogeco 