### PR TITLE
Fix #167, Update doc generation action error check

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -103,8 +103,8 @@ jobs:
 
       - name: Warning Check
         run: |
-          if [[ -s build/doc/warnings.log ]]; then
-            cat build/doc/warnings.log
+          if [[ -s usersguide_warnings.log ]]; then
+            cat usersguide_warnings.log
             exit -1
           fi
 
@@ -159,7 +159,7 @@ jobs:
 
       - name: Warning Check
         run: |
-          if [[ -s build/doc/warnings.log ]]; then
-            cat build/doc/warnings.log
+          if [[ -s osalguide_warnings.log ]]; then
+            cat osalguide_warnings.log
             exit -1
           fi


### PR DESCRIPTION
**Describe the contribution**
Fix #167 

Warning file is moved in Build Usersguide step.
Updated from checking the old file location to
checking the moved file.

**Testing performed**
Pushed to fork and observed the doc warnings are reported in actions.

**Expected behavior changes**
Actually reports when warnings are generated

**System(s) tested on**
 - Hardware: CI

**Additional context**
Actual fixes to the warnings will be in respective repos

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC