### PR TITLE
Fix #166 and #169, Add Static Code Analysis and Pull Request Trigger to CI workflow

### DIFF
--- a/.github/workflows/build-cfs-deprecated.yml
+++ b/.github/workflows/build-cfs-deprecated.yml
@@ -1,11 +1,10 @@
 name: "Deprecated Build, Test, and Run"
 
 # Run this workflow every time a new commit pushed to your repository
-on: push
+on: [push, pull_request]
 
 env:
   SIMULATION: native
-  ENABLE_UNIT_TESTS: true
   OMIT_DEPRECATED: false
 
 jobs:
@@ -18,6 +17,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     strategy:
+      fail-fast: false
       matrix:
         buildtype: [debug, release]
 
@@ -51,12 +51,15 @@ jobs:
     runs-on: ubuntu-18.04
 
     strategy:
+      fail-fast: false
       matrix:
         buildtype: [debug, release]
 
     # Set the type of machine to run on
     env:
       BUILDTYPE: ${{ matrix.buildtype }}
+      ENABLE_UNIT_TESTS: true
+
 
     steps:
       - name: Install Dependencies
@@ -90,6 +93,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     strategy:
+      fail-fast: false
       matrix:
         buildtype: [debug, release]
 

--- a/.github/workflows/build-cfs.yml
+++ b/.github/workflows/build-cfs.yml
@@ -5,13 +5,9 @@ on: push
 
 env:
   SIMULATION: native
-  ENABLE_UNIT_TESTS: true
   OMIT_DEPRECATED: true
 
 jobs:
-
-  # Set the job key. The key is displayed as the job name
-  # when a job name is not provided
 
   build-cfs:
     name: Build
@@ -47,8 +43,9 @@ jobs:
 
   test-cfs:
     name: Test
-    needs: build-cfs
     runs-on: ubuntu-18.04
+
+    needs: build-cfs
 
     strategy:
       matrix:
@@ -57,6 +54,8 @@ jobs:
     # Set the type of machine to run on
     env:
       BUILDTYPE: ${{ matrix.buildtype }}
+      ENABLE_UNIT_TESTS: true
+
 
     steps:
       - name: Install Dependencies

--- a/.github/workflows/build-cfs.yml
+++ b/.github/workflows/build-cfs.yml
@@ -1,7 +1,7 @@
 name: Build, Test, and Run [OMIT_DEPRECATED=true]
 
-# Run this workflow every time a new commit pushed to your repository
-on: push
+# Run this workflow every time a new commit pushed to your repository or for new pull requests
+on: [push, pull_request]
 
 env:
   SIMULATION: native
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     strategy:
+      fail-fast: false
       matrix:
         buildtype: [debug, release]
 
@@ -22,7 +23,7 @@ jobs:
       BUILDTYPE: ${{ matrix.buildtype }}
 
     steps:
-      # Checks out a copy of your repository on the ubuntu-latest machine
+      # Check out the cfs bundle
       - name: Checkout code
         uses: actions/checkout@v2
         with:
@@ -48,6 +49,7 @@ jobs:
     needs: build-cfs
 
     strategy:
+      fail-fast: false
       matrix:
         buildtype: [debug, release]
 
@@ -89,6 +91,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     strategy:
+      fail-fast: false
       matrix:
         buildtype: [debug, release]
 

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -1,7 +1,7 @@
 name: Documentation and Guides
 
-# Run this workflow every time a new commit pushed to your repository
-on: push
+# Run this workflow every time a new commit pushed to your repository or for new pull requests
+on: [push, pull_request]
 
 env:
   SIMULATION: native
@@ -9,22 +9,20 @@ env:
 jobs:
 
   build-docs:
-    # Name the Job
     name: cFE Documentation
-    # Set the type of machine to run on
     runs-on: ubuntu-18.04
 
     steps:
       - name: Install Dependencies
         run: sudo apt-get install doxygen graphviz -y
 
-      # Checks out a copy of your repository on the ubuntu-latest machine
+        # Check out the cfs bundle
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           submodules: true
 
-      # Setup the build system
+      # Prepare build "recipes"
       - name: Copy Files
         run: |
           cp ./cfe/cmake/Makefile.sample Makefile
@@ -38,7 +36,8 @@ jobs:
         run: |
           make doc > make_doc_stdout.txt 2> make_doc_stderr.txt
 
-      - name: Archive Users Guide Build Logs
+      # Upload documentation logs as artifacts
+      - name: Archive Documentation Build Logs
         uses: actions/upload-artifact@v2
         with:
           name: cFS Docs Artifacts

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,25 +1,16 @@
 name: Static Analysis
 
 # Run this workflow every time a new commit pushed to your repository
-on: push
-
-env:
-  SIMULATION: native
+on: [push, pull_request]
 
 jobs:
-
-  # Set the job key. The key is displayed as the job name
-  # when a job name is not provided
 
   static-analysis:
     name: Run cppcheck
     runs-on: ubuntu-18.04
 
     strategy:
-<<<<<<< HEAD
-=======
       fail-fast: false
->>>>>>> aeda0dd... remove 'quiet' from cfe, osal, and psp checks
       matrix:
         cppcheck: [bundle, cfe, osal, psp]
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,72 @@
+name: Static Analysis
+
+# Run this workflow every time a new commit pushed to your repository
+on: push
+
+env:
+  SIMULATION: native
+
+jobs:
+
+  # Set the job key. The key is displayed as the job name
+  # when a job name is not provided
+
+  static-analysis:
+    name: Run cppcheck
+    runs-on: ubuntu-18.04
+
+    strategy:
+<<<<<<< HEAD
+=======
+      fail-fast: false
+>>>>>>> aeda0dd... remove 'quiet' from cfe, osal, and psp checks
+      matrix:
+        cppcheck: [bundle, cfe, osal, psp]
+
+    steps:
+
+      - name: Install cppcheck
+        run: sudo apt-get install cppcheck -y
+
+        # Checks out a copy of the cfs bundle
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Run bundle cppcheck
+        if: ${{matrix.cppcheck =='bundle'}}
+        run: cppcheck --force --inline-suppr --quiet . 2> ${{matrix.cppcheck}}_cppcheck_err.txt
+
+        # Run strict static analysis for embedded portions of cfe, osal, and psp
+      - name: cfe strict cppcheck
+        if: ${{matrix.cppcheck =='cfe'}}
+        run: |
+          cd ${{matrix.cppcheck}}
+          cppcheck --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./fsw/cfe-core/src ./modules 2> ../${{matrix.cppcheck}}_cppcheck_err.txt
+
+      - name: osal strict cppcheck
+        if: ${{matrix.cppcheck =='osal'}}
+        run: |
+          cd ${{matrix.cppcheck}}
+          cppcheck --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./src/bsp ./src/os 2> ../${{matrix.cppcheck}}_cppcheck_err.txt
+
+      - name: psp strict cppcheck
+        if: ${{matrix.cppcheck =='psp'}}
+        run: |
+          cd ${{matrix.cppcheck}}
+          cppcheck --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./fsw 2> ../${{matrix.cppcheck}}_cppcheck_err.txt
+
+      - name: Archive Static Analysis Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{matrix.cppcheck}}-cppcheck-err
+          path: ./*cppcheck_err.txt
+
+      - name: Check for errors
+        run: |
+          if [[ -s ${{matrix.cppcheck}}_cppcheck_err.txt ]];
+          then
+            cat ${{matrix.cppcheck}}_cppcheck_err.txt
+            exit -1
+          fi


### PR DESCRIPTION
**Describe the contribution**
Fix #166
Fix #169 

**Testing performed**
Succesfully ran in fork.

Also see pull-request trigger working at https://github.com/nasa/cFS/pull/171/checks

**Expected behavior changes**
New workflow "Static Analysis" runs cpp check on the bundle and also stricter checks on cfe, osal, and psp based on the old travis.yml setups.

**System(s) tested on**
Ubuntu 18.04

**Additional context**
None
