### PR TITLE
Fix #198, Fix Contributions Spelling Error in PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@ A clear and concise description of how this contribution will change behavior an
 **Additional context**
 Add any other context about the contribution here.
 
-**Code contibutions**
+**Code contributions**
 The cFS repository is provided to bundle the cFS Framework.  It is utilized for bundling submodules, continuous integration testing, and version management and does not contain any software.  Code contributions should be directed to the appropriate submodule.
 
 **Contributor Info - All information REQUIRED for consideration of pull request**


### PR DESCRIPTION
**Describe the contribution**
Fix #198 
Changed Code contibutions to Code contributions to fix the spelling error in the PR template. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal
