### PR TITLE
Fix #201, Create Changelog GitHub Actions Workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,34 @@
+name: Changelog
+
+# Controls when the action will run. 
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Run Changelog
+        uses: heinrichreimer/github-changelog-generator-action@v2.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issuesLabel: "### Closed issues" 
+          breakingLabel: "### Breaking changes" 
+          enhancementLabel: "### Implemented enhancements" 
+          bugsLabel: "### Fixed bugs" 
+          deprecatedLabel: "### Deprecated" 
+          removedLabel: "### Removed" 
+          securityLabel: "### Security fixes"
+          pullRequests: false
+          author: false
+        
+      - name: "Upload changelog"
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: "Changelog"
+          path: CHANGELOG.md
+          


### PR DESCRIPTION
**Describe the contribution**
Fix #201 
Created a changelog GitHub actions workflow that is triggered manually. The workflow organizes issues for each release in the sections, closed issues, breaking changes, implemented enhancements, fixed bugs, deprecated, removed, and security fixes. Pull requests are not displayed.

**Expected behavior changes**
When the user manually triggers the workflow, a changelog.md file is created. 

**System(s) tested on**
Tested on my forked repo. 

**Additional context**
References: https://github.com/heinrichreimer/action-github-changelog-generator

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal 
