### PR TITLE
Fix #209, Add Checklist to Bug Report Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,11 @@ assignees: ''
 
 ---
 
+**Checklist (Please check before submitting)**
+
+* [ ] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
+* [ ] I performed a cursory search to see if the bug report is relevant, not redundant, nor in conflict with other tickets.
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 


### PR DESCRIPTION
**Describe the contribution**
Fix #209
Added a checklist to the bug report template to enforce users to review the contributing guide and ensure that their bug report is is relevant, not redundant, nor in conflict with other tickets.

**Expected behavior changes**
The checklist helps prevent redundant or irrelevant issues from being submitted. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal
