### PR TITLE
Fix #205, Remove Duplicate Workflows

### DIFF
--- a/.github/workflows/build-cfs-deprecated.yml
+++ b/.github/workflows/build-cfs-deprecated.yml
@@ -1,11 +1,8 @@
 name: "Deprecated Build, Test, and Run"
 
-# Run every time a new commit pushed to main or for pull requests
+# Run every time a new commit pushed or for pull requests
 on:
   push:
-    branches:
-      - main
-
   pull_request:
 
 env:
@@ -13,11 +10,27 @@ env:
   OMIT_DEPRECATED: false
 
 jobs:
-
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  duplicate-job:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+        should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+          
   # Set the job key. The key is displayed as the job name
   # when a job name is not provided
 
   build-cfs:
+    #Continue if duplicate-job found no duplicates. Always runs for pull-requests.
+    needs: duplicate-job
+    if: ${{ needs.duplicate-job.outputs.should_skip != 'true' }}
     name: Build
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/build-cfs.yml
+++ b/.github/workflows/build-cfs.yml
@@ -1,11 +1,8 @@
 name: Build, Test, and Run [OMIT_DEPRECATED=true]
 
-# Run every time a new commit pushed to main or for pull requests
+# Run every time a new commit pushed or for pull requests
 on:
   push:
-    branches:
-      - main
-
   pull_request:
 
 env:
@@ -13,8 +10,24 @@ env:
   OMIT_DEPRECATED: true
 
 jobs:
-
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  duplicate-job:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+        should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+          
   build-cfs:
+    #Continue if duplicate-job found no duplicates. Always runs for pull-requests.
+    needs: duplicate-job
+    if: ${{ needs.duplicate-job.outputs.should_skip != 'true' }}
     name: Build
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -13,25 +13,45 @@ env:
   BUILDTYPE: release
 
 jobs:
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  duplicate-job:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
 
+      
   CodeQL-Build:
+    #Continue if duplicate-job found no duplicates. Always runs for pull-requests.
+    needs: duplicate-job
+    if: ${{ needs.duplicate-job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-18.04
     timeout-minutes: 15
 
     steps:
       # Checks out a copy of your repository
       - name: Checkout code
+        if: ${{ !steps.skip-workflow.outputs.skip }}
         uses: actions/checkout@v2
         with:
           repository: nasa/cFS
           submodules: true
 
       - name: Check versions
+        if: ${{ !steps.skip-workflow.outputs.skip }}
         run: |
            git log -1 --pretty=oneline
            git submodule
 
       - name: Initialize CodeQL
+        if: ${{ !steps.skip-workflow.outputs.skip }}
         uses: github/codeql-action/init@v1
         with:
           languages: c
@@ -39,14 +59,17 @@ jobs:
 
       # Setup the build system
       - name: Copy sample_defs
+        if: ${{ !steps.skip-workflow.outputs.skip }}
         run: |
           cp ./cfe/cmake/Makefile.sample Makefile
           cp -r ./cfe/cmake/sample_defs sample_defs
 
       # Setup the build system
       - name: Make Install
+        if: ${{ !steps.skip-workflow.outputs.skip }}
         run: make
 
       # Run CodeQL
       - name: Perform CodeQL Analysis
+        if: ${{ !steps.skip-workflow.outputs.skip }}
         uses: github/codeql-action/analyze@v1

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,16 +1,29 @@
 name: Static Analysis
 
-# Run this workflow every time a new commit pushed to your repository
+# Run this workflow every time a new commit pushed to your repository and for pull requests
 on:
   push:
-    branches:
-      - main
-
   pull_request:
 
 jobs:
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  duplicate-job:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+        should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
 
   static-analysis:
+    #Continue if duplicate-job found no duplicates. Always runs for pull-requests.
+    needs: duplicate-job
+    if: ${{ needs.duplicate-job.outputs.should_skip != 'true' }}
     name: Run cppcheck
     runs-on: ubuntu-18.04
 
@@ -19,8 +32,7 @@ jobs:
       matrix:
         cppcheck: [bundle, cfe, osal, psp]
 
-    steps:
-
+    steps:      
       - name: Install cppcheck
         run: sudo apt-get install cppcheck -y
 


### PR DESCRIPTION
**Describe the contribution**
Fix #205 
Removed the main branch in the static analysis, deprecated build, run, and test, and omit deprecated workflows for push. All four workflows, codeql, static analysis, deprecated build, run, and test, and omit deprecated uses a GitHub action to skip any duplication workflows. 

**Testing performed**
Tested on my [forked repository](https://github.com/ArielSAdamsNASA/cFS/pull/8). Created a pull request and pushed changes to test. 

**Expected behavior changes**
The static analysis, deprecated build, run, and test, and omit deprecated workflows now run on all branches when code is pushed. The codeql workflow already allowed this. The changes allow the workflows to run on all branches when users are wanting to test their commits on their forked repos. 

The GitHub action used skips push workflows, instead of pull request workflows, and does not cause these skips to fail the checks. So, there should be no duplicate GitHub Actions Workflows. 

**Additional context**
References: https://github.com/fkirc/skip-duplicate-actions/#skip-concurrent-workflow-runs, https://github.com/marketplace/actions/skip-duplicate-actions

Travis CI still runs for all push and pull requests and there are duplicate runs for this tool when tested on the forked repo pull request. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal 
