### PR TITLE
Fix #234, Documentation and Guides Workflow Run on All Push Events

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -3,17 +3,30 @@ name: Documentation and Guides
 # Run every time a new commit pushed to main or for pull requests
 on:
   push:
-    branches:
-      - main
-
   pull_request:
 
 env:
   SIMULATION: native
 
 jobs:
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  checks-for-duplicates:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
 
   build-docs:
+    #Continue if checks-for-duplicates found no duplicates. Always runs for pull-requests.
+    needs: checks-for-duplicates
+    if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' }}
     name: cFE Documentation
     runs-on: ubuntu-18.04
 
@@ -220,4 +233,3 @@ jobs:
           FOLDER: deploy
           CLEAN: false
           SINGLE_COMMIT: true
-


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #234
- Removed the main branch for push so that the workflow runs on all branches for push and pull requests. 
- Added the duplicate jobs action so that the workflow does not run any duplicate jobs. 

**Testing performed**
Tested [locally](https://github.com/ArielSAdamsNASA/cFS/actions/runs/722775122)

**Expected behavior changes**
- The Documentation and Guides workflow should run on all push events. For example, when users push code to their forked repos, the Documentation and Guides workflow should run. 
- When a user pushes code to a pull request, the workflow should not run duplicate jobs for both push and pull requests. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal 
