### PR TITLE
Fix #251, Implement Coding Standard Rules in CodeQL

### DIFF
--- a/.github/codeql/codeql-coding-standard.yml
+++ b/.github/codeql/codeql-coding-standard.yml
@@ -1,0 +1,20 @@
+name: "CodeQL Coding Standard Configuration File"
+
+disable-default-queries: true
+
+queries:
+  - name: JPL Rules
+    uses: ./codeql/cpp/ql/src/JPL_C
+  - name: MISRA Rule 9-5-1
+    uses: ./codeql/cpp/ql/src/jsf/4.20 Unions and Bit Fields/AV Rule 153.ql
+  - name: MISRA Rule 5-18-1
+    uses: ./codeql/cpp/ql/src/jsf/4.21 Operators/AV Rule 168.ql 
+  - name: MISRA 6-2-2
+    uses: ./codeql/cpp/ql/src/jsf/4.25 Expressions/AV Rule 202.ql
+  - name: MISRA Rule 5-14-1
+    uses: ./codeql/cpp/ql/src/jsf/4.21 Operators/AV Rule 165.ql
+  - name: MISRA Rule 5-3-2
+    uses: ./codeql/cpp/ql/src/jsf/4.21 Operators/AV Rule 165.ql
+  - name: MISRA Rule 7-5-2
+    uses: ./codeql/cpp/ql/src/jsf/4.22 Pointers and References/AV Rule 173.ql
+

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,5 +1,0 @@
-name: "CodeQL Configuration File"
-
-queries:
-  - uses: security-and-quality
-  - uses: security-extended 

--- a/.github/codeql/codeql-security.yml
+++ b/.github/codeql/codeql-security.yml
@@ -1,0 +1,7 @@
+name: "CodeQL Security Configuration File"
+
+queries:
+  - name: Security and Quality
+    uses: security-and-quality
+  - name: Security Extended
+    uses: security-extended 

--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -28,7 +28,7 @@ jobs:
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
 
       
-  CodeQL-Build:
+  CodeQL-Security-Build:
     #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
@@ -55,7 +55,61 @@ jobs:
         uses: github/codeql-action/init@v1
         with:
           languages: c
-          config-file: ./.github/codeql/codeql-config.yml
+          config-file: ./.github/codeql/codeql-security.yml
+
+      # Setup the build system
+      - name: Copy sample_defs
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make Install
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        run: make
+
+      # Run CodeQL
+      - name: Perform CodeQL Analysis
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        uses: github/codeql-action/analyze@v1
+
+  CodeQL-Coding-Standard-Build:
+    #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
+    needs: check-for-duplicates
+    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-18.04
+    timeout-minutes: 15
+
+    steps:
+      # Checks out a copy of your repository
+      - name: Checkout code
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        uses: actions/checkout@v2
+        with:
+          repository: nasa/cFS
+          submodules: true
+
+      - name: Check versions
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        run: |
+           git log -1 --pretty=oneline
+           git submodule
+
+      - name: Checkout codeql code      
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        uses: actions/checkout@v2
+        with:
+          repository: github/codeql 
+          submodules: true 
+          path: codeql
+
+      - name: Initialize CodeQL
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        uses: github/codeql-action/init@v1
+        with:
+          languages: c
+          config-file: ./.github/codeql/codeql-coding-standard.yml
 
       # Setup the build system
       - name: Copy sample_defs


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fix #251 
Added JPL rules to configuration guide to follow the coding standard. CodeQL provides some MISRA rules scattered in its repository. 

* cpp/ql/src/jsf/4.21 Operators/AV Rule 165.ql - MISRA Rule 5-3-2
*  cpp/ql/src/jsf/4.22 Pointers and References/AV Rule 173.ql - MISRA Rule 7-5-2
* cpp/ql/src/jsf/4.21 Operators/AV Rule 157.ql - MISRA Rule 5-14-1
* cpp/ql/src/jsf/4.21 Operators/AV Rule 168.ql - MISRA Rule 5-18-1
* cpp/ql/src/jsf/4.25 Expressions/AV Rule 202.ql - MISRA 6-2-2
* cpp/ql/src/jsf/4.20 Unions and Bit Fields/AV Rule 153.ql - MISRA Rule 9-5-1

**Testing performed**
Tested locally. JPL rules can be seen here: 
![image](https://user-images.githubusercontent.com/69638935/117461168-e15a5d80-af12-11eb-8461-b4ca0ebba161.png)

**Expected behavior changes**
CodeQL should scan for violations against JPL rules and a few MISRA rules. 

**Additional context**
Can create a separate workflows. One for the coding standards and another for the security queries. 

Note that users can search through results based on rules, but I believe this can be done one rule at a time. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal 
