### PR TITLE
Fix #257, Correct links to community mailing list

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -27,7 +27,7 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 This Code of Conduct applies within all project spaces, and it also applies when an individual is representing the project or its community in public spaces. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
 
 ## Enforcement
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at cfs-program@lists.nasa.gov. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by [contacting the cFS Product Team](README.md#contact-the-cfs-product-team). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,26 +16,29 @@ So you'd like to contribute to cFS? Below are some guidelines for contributors t
 
 [Quick Links to Submodules](#quick-links-to-submodules)
 
-## Code of Conduct 
-This project and everyone participating in it is governed by the [cFS Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to the project team at cfs-program@lists.nasa.gov.
+## Code of Conduct
+
+This project and everyone participating in it is governed by the [cFS Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to the [product team](README.md#contact-the-cfs-product-team).
 
 ## Ways to Contribute
 
 ### Discussions and Questions
-For questions or help, submit a GitHub isssue or email us at cfs-program@lists.nasa.gov. 
 
-[Subscribe to our mailing list](https://lists.nasa.gov/mailman/listinfo/cfs-community) that includes all the community members/users of the NASA core Flight Software (cFS) product line. The mailing list is used to communicate any information related to the cFS product such as current releases, bug findings and fixes, enhancement requests, community meeting notifications, sending out meeting minutes, etc.
+For questions or help, submit a GitHub issue, [join the cfs community mailing list](README.md#join-the-mailing-list).
+
 
 ### Report Bugs
+
 #### Before Submitting a Bug
 1. Perform a cursory search to see if the bug has already been reported. For issues in each submodule, visit the section [Quick Links to Submodules](#quick-links-to-submodules). If a bug has been reported and the issue is still open, add a comment to the existing issue instead of opening a new one.
 2. Determine which repository the bug should be reported in. If you are not sure, place the [issue in NASA/cFS](https://github.com/nasa/cFS/issues/new?assignees=&labels=&template=bug_report.md&title=).
 
 #### Reporting a Bug
+
 If you run into a bug with the project:
-1. Open an issue using the bug report template. 
-2. Describe the issue. 
-3. Describe the expected behavior if the bug did not occur. 
+1. Open an issue using the bug report template.
+2. Describe the issue.
+3. Describe the expected behavior if the bug did not occur.
 4. Provide the reproduction steps that someone else can follow to recreate the bug or error on their own.
 5. If applicable, add code snippets or references to the software.
 6. Provide the system the bug was observed on including the hardware, operating system, and versions.
@@ -48,12 +51,12 @@ If you run into a bug with the project:
 
 ### Feature Requests
 #### Before Submitting a Feature Request
-1. Review the cFS README.md file to see if your feature is in the major future work. 
+1. Review the cFS README.md file to see if your feature is in the major future work.
 2. Perform a cursory search to see if the feature has already been requested. For issues in each submodule, visit the section [Quick Links to Submodules](#quick-links-to-submodules). If a feature request has been reported and the issue is still open, add a comment to the existing issue instead of opening a new one.
 3. Determine which repository the feature should be reported in. If you are not sure, [place the issue in NASA/cFS](https://github.com/nasa/cFS/issues/new?assignees=&labels=&template=feature_request.md&title=).
 
 #### Submitting a Feature Request
-1. Open an issue using the feature request template. 
+1. Open an issue using the feature request template.
 2. Describe the feature.
 3. Describe the solution you would like.
 4. Describe alternatives you've considered.
@@ -101,7 +104,7 @@ Fix #XYZ, SHORT_DESCRIPTION
 
 LONG_DESCRIPTION (optional)
 ```
-2. Verify there is one commit message per topic. For example, review the [provided pull request](https://github.com/nasa/cFE/pull/1203/commits). 
+2. Verify there is one commit message per topic. For example, review the [provided pull request](https://github.com/nasa/cFE/pull/1203/commits).
 3. Squash or amend the commit messages if necessary. For more information, review the sections [How to Squash Commits](#how-to-squash-commits) and [How to Amend Commits](#how-to-amend-commits) .  
 3. Verify that the PR passes all checks.
 4. The project team will label the issue and evaluate the pull request in the weekly configuration control board (CCB) meeting. For more information, visit [The cFS CCB Process](https://github.com/nasa/cFS/wiki/The-cFS-CCB-Process).
@@ -137,18 +140,18 @@ squash 6b2481b do something else
 squash dd1475d changed some things
 squash c619268 fixing typos
 ```
-or 
+or
 ```sh
 r 1fc6c95 do something
 f 6b2481b do something else
 f dd1475d changed some things
 f c619268 fixing typos
 ```
-6. Save and close the file. If you used "pick" and "squash", a new file should pop up in your editor, combining all the commit messages of all the commits. Reword this commit message as you want, and then save and close that file as well. 
+6. Save and close the file. If you used "pick" and "squash", a new file should pop up in your editor, combining all the commit messages of all the commits. Reword this commit message as you want, and then save and close that file as well.
 
 7. Push the commit:
 ```sh
-git push --force 
+git push --force
 ```
 
 ##### Soft Reset
@@ -170,10 +173,10 @@ LONG_DESCRIPTION (optional)"
 ```
 4. Push the commit:
 ```sh
-git push --force 
+git push --force
 ```
 
-##### Replace Branch 
+##### Replace Branch
 This method had no chances of inadvertently overwriting other stuff.
 
 1. Make a new branch with a new name at the current main:
@@ -187,14 +190,14 @@ git merge --squash ${old_branch}
 3. Test the result, then commit to write a new commit message summarizing the full change:
 ```sh
 git commit
-``` 
-4. Rename your new branch over your old branch to replace it: 
+```
+4. Rename your new branch over your old branch to replace it:
 ```sh
 git branch -m -f ${new_branch} ${old_branch}
 ```
 5. Push to GitHub:
 ```sh
-git push --force 
+git push --force
 ```
 
 #### How to Amend Commits
@@ -204,7 +207,7 @@ git commit --amend
 ```
 2. The previous commit message will load an editor session, where you can make changes to the message, save those changes and exit. When you save and close the editor, the editor writes a new commit containing that updated commit message and makes it your new last commit. Push the new changes:
 ```sh
-git push --force 
+git push --force
 ```
 
 1. To change the actual content of your last commit, stage those changes:
@@ -217,7 +220,7 @@ git commit --amend
 ```
 3. Now the last commit is replaced by your new and improved commit. Push the commit:
 ```sh
-git push --force 
+git push --force
 ```
 
 ## Writing High-Quality Code
@@ -225,7 +228,7 @@ git push --force
 1. Follow cFS code conventions (formatting, symbol naming, file naming, etc). Do *not* change/reformat existing code, except to address your changes.
     - The cFS submodules uses the Format Check workflow to ensure users follow the [clang-format-10](https://github.com/nasa/cFS/blob/main/.clang-format) style. For more information on how to use the Format Check workflow, view [Using GitHub Actions Workflows](#using-github-actions-workflows).  
     - The [cFS_IdentifierNamingConvention document](https://github.com/nasa/cFE/blob/main/docs/cFS_IdentifierNamingConvention.md) provides a simple naming convention guide for cFE/cFS for commands and telemetry that simplifies the EDS to ground telemetry and commands database conversion.
-    - The [cFE Application Developers Guide](https://github.com/nasa/cFE/blob/main/docs/cFE%20Application%20Developers%20Guide.md) contains code conventions such as naming conventions for header files. 
+    - The [cFE Application Developers Guide](https://github.com/nasa/cFE/blob/main/docs/cFE%20Application%20Developers%20Guide.md) contains code conventions such as naming conventions for header files.
 
 2. For any new API's, add unit tests to cover nominal and off-nominal conditions.
 
@@ -234,38 +237,38 @@ git push --force
 4. For any changes to existing API's, alter the unit tests to cover the changes (and remove tests made irrelevant due to your changes).
 
 5. Review the static code analyses results from the Static Analysis and CodeQL Analysis workflows. For more information on how to use these workflows, view [Using GitHub Actions Workflows](#using-github-actions-workflows).  
-    - Push code changes to the appropriate forked repository. 
-    - Go to the Actions tab and enable GitHub Actions Workflow. The CodeQL Analyis and Static Analysis will be triggered for all pushed code. 
-    - Review these workflows for any warnings or errors. 
+    - Push code changes to the appropriate forked repository.
+    - Go to the Actions tab and enable GitHub Actions Workflow. The CodeQL Analyis and Static Analysis will be triggered for all pushed code.
+    - Review these workflows for any warnings or errors.
     - Once successful, create a pull request.
 
 ### Using GitHub Actions Workflows
 
-Several of our GitHub Actions Workflows are used to ensure pushed code and pull requests do not break cFS, create vulnerabilities, and follow our code conventions. Other workflows are used for documentation purposes. 
+Several of our GitHub Actions Workflows are used to ensure pushed code and pull requests do not break cFS, create vulnerabilities, and follow our code conventions. Other workflows are used for documentation purposes.
 
-Most of the workflows in the NASA/cFS repository will run for all branches when code is pushed and a pull request is created, except for the changelog workflow that runs manually. 
+Most of the workflows in the NASA/cFS repository will run for all branches when code is pushed and a pull request is created, except for the changelog workflow that runs manually.
 
 All of our workflows will be available for forked repositories once enabled. To enable workflows, navigate to the Actions tab and click "I understand my workflows, go ahead and enable them".
 
 #### View Failed Workflows
 
-1. Navigate to Actions in the selected repository. For newly forked repositories, enable workflows after clicking on Actions. 
+1. Navigate to Actions in the selected repository. For newly forked repositories, enable workflows after clicking on Actions.
 2. In the left sidebar, click the workflow you want to view.
 3. From the list of workflow runs, click the name of the run you want to see.
 4. Under Jobs or in the visualization graph, click the failed job.
 5. Any failed steps are automatically expanded to display the results.
 
 #### View Workflow Results
-1. Navigate to Actions in the selected repository. For newly forked repositories, enable workflows after clicking on Actions. 
+1. Navigate to Actions in the selected repository. For newly forked repositories, enable workflows after clicking on Actions.
 2. In the left sidebar, click the workflow you want to view.
 3. From the list of workflow runs, click the name of the run you want to see.
-4. Scroll to the bottom of the page and download the artifacts. For CodeQL results, navigate to the Security Tab and click Code scanning alerts. CodeQL results will only be avaiable on your forked repository. 
+4. Scroll to the bottom of the page and download the artifacts. For CodeQL results, navigate to the Security Tab and click Code scanning alerts. CodeQL results will only be avaiable on your forked repository.
 
-or 
+or
 
-1. In pull requests, click the Checks tab. 
+1. In pull requests, click the Checks tab.
 2. From the list of workflow runs, click the name of the run you want to see.
-4. Scroll to the bottom of the page and download the artifacts. For CodeQL results, expand Code scanning alerts at the bottom of the list of checks and select CodeQL. 
+4. Scroll to the bottom of the page and download the artifacts. For CodeQL results, expand Code scanning alerts at the bottom of the list of checks and select CodeQL.
 
 #### Configure Workflows
 
@@ -276,18 +279,19 @@ or
 
 Additional information on our GitHub Action Workflows can be found in our [Security Policy](https://github.com/nasa/cFS/security/policy).
 
-##### Format Check 
+##### Format Check
 [![Format Check](https://github.com/nasa/osal/actions/workflows/format-check.yml/badge.svg)](https://github.com/nasa/osal/actions/workflows/format-check.yml)
 
-This action uses clang-format-10 to check for format errors. 
+This action uses clang-format-10 to check for format errors.
 
-##### CodeQL Analysis 
+##### CodeQL Analysis
 [![CodeQL Analaysis](https://github.com/nasa/cfs/actions/workflows/codeql-build.yml/badge.svg)](https://github.com/nasa/cfs/actions/workflows/codeql-build.yml)
 
 This action runs GitHub's industry-leading static analysis engine, CodeQL, against our repository's source code to find security vulnerabilities. It then automatically uploads the results to GitHub so they can be displayed in the repository's code scanning alerts found under the security tab. CodeQL runs an extensible set of [queries](https://github.com/github/codeql), which have been developed by the community and the [GitHub Security Lab](https://securitylab.github.com/) to find common vulnerabilities in your code.
 
 Our CodeQL action uses a configuration file to use specific queries, which can be found at [.github/codeql](https://github.com/nasa/cFS/tree/main/.github/codeql).
- 
+
+
 ##### Static Analaysis
 [![Static Analaysis](https://github.com/nasa/cfs/actions/workflows/static-analysis.yml/badge.svg)](https://github.com/nasa/cfs/actions/workflows/static-analysis.yml)
 
@@ -296,22 +300,22 @@ This action runs a static analysis tool for C/C++ code known as cppcheck. Cppche
 ##### Deprecated Build, Test, and Run
 [![Deprecated Build, Test, and Run](https://github.com/nasa/cfs/actions/workflows/build-cfs-deprecated.yml/badge.svg)](https://github.com/nasa/cfs/actions/workflows/build-cfs-deprecated.yml)
 
-This action builds, tests, and runs the cFS bundle using deprecated code. 
+This action builds, tests, and runs the cFS bundle using deprecated code.
 
 ##### Build, Test, and Run [OMIT_DEPRECATED=true]
 [![Build, Test, and Run %5B OMIT_DEPRECATED=true %5B](https://github.com/nasa/cfs/actions/workflows/build-cfs.yml/badge.svg)](https://github.com/nasa/cfs/actions/workflows/build-cfs.yml)
 
-This action builds, tests, and runs the cFS bundle omitting deprecated code. 
+This action builds, tests, and runs the cFS bundle omitting deprecated code.
 
 ##### Documentation and Guides
 [![Documentation and Guides](https://github.com/nasa/cfs/actions/workflows/build-documentation.yml/badge.svg)](https://github.com/nasa/cfs/actions/workflows/build-documentation.yml)
 
-This action creates doxygen documents for cFE, cFS users guide, and osal guide. 
+This action creates doxygen documents for cFE, cFS users guide, and osal guide.
 
 ##### Changelog
 [![Changelog](https://github.com/nasa/cfs/actions/workflows/changelog.yml/badge.svg)](https://github.com/nasa/cfs/actions/workflows/changelog.yml)
 
-This action creates a changelog file which documents all the issues in cFS. 
+This action creates a changelog file which documents all the issues in cFS.
 
 ##### Local Unit Test
 [![Local Unit Test](https://github.com/nasa/osal/actions/workflows/local_unit_test.yml/badge.svg)](https://github.com/nasa/osal/actions/workflows/local_unit_test.yml)

--- a/README.md
+++ b/README.md
@@ -73,9 +73,19 @@ See related repositories for current open issues.
 
 For best results, submit issues:questions or issues:help wanted requests to this repo.
 
-Official cFS page: http://cfs.gsfc.nasa.gov
 
-Community email list subscription request: https://lists.nasa.gov/mailman/listinfo/cfs-community
+### Join the mailing list
+
+To **subscribe to our mailing list,** send an email to cfs-community-join@lists.nasa.gov with the word *subscribe* in the subject line.
+
+The cfs-community mailing list includes cFS users and developers. The cFS Product Team also uses the mailing list to share information on current and future releases, bug findings and fixes, enhancement requests, community meetings, etc.
+
+If you'd like to unsubscribe, send an email with the word *unsubscribe* to cfs-community-leave@lists.nasa.gov. Mailing list requests are typically processed within 5 minutes.
+
+### Contact the cFS Product Team
+
+You can email the cFS Product Team at cfs-program@lists.nasa.gov to explore partnerships and other arrangements for in-depth support.
+
 
 ## Setup
 
@@ -112,7 +122,7 @@ Note: The steps above are for a debug, permissive mode build and includes deprec
 The cFS-GroundSystem tool can be used to send commands and receive telemetry.  For details on using and setting up the Ground System, see the [Guide-GroundSystem](https://github.com/nasa/cFS-GroundSystem/blob/main/Guide-GroundSystem.md).  Note it depends on PyQt5 and PyZMQ:
 
 1. Install PyQt5 and PyZMQ on your system.  Some systems may also require installing libcanberra-gtk-module.
-       
+
 2. Compile cmdUtil and start the ground system executable
 
        cd tools/cFS-GroundSystem/Subsystems/cmdUtil
@@ -155,7 +165,7 @@ The following list is user submitted, and not CCB controlled.  They are released
     - SCA: Stored Command Absolute application at https://github.com/nasa/SCA
     - SCH: Scheduler application at https://github.com/nasa/SCH
     - TO: Telemetry Output application at https://github.com/nasa/CFS_TO
-    - Skeleton App: A bare-bones application to which you can add your business logic at https://github.com/nasa/skeleton_app 
+    - Skeleton App: A bare-bones application to which you can add your business logic at https://github.com/nasa/skeleton_app
   - Other Interfaces
     - SIL: Simulink Interface Layer at https://github.com/nasa/SIL
     - ECI: External Code Interface at https://github.com/nasa/ECI
@@ -170,4 +180,4 @@ The following list is user submitted, and not CCB controlled.  They are released
     - TBD
   - Other PSPs
     - TBD
-  
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,27 +2,31 @@
 
 ## Reporting a Vulnerability
 
-For general cFS vulnerabilities, please [open a cFS framework issue](https://github.com/nasa/cfs/issues/new/choose). Please use the "Bug Report" template and provide as much information as possible. Apply appropraite labels for each report.  
+For general cFS vulnerabilities, please [open a cFS framework issue](https://github.com/nasa/cfs/issues/new/choose). Please use the "Bug Report" template and provide as much information as possible. Apply appropriate labels for each report.  
 
 For security related vulnerabilities, follow the general cFS vulnerabilites instructions and tag the issue with the "security" label.
 
+## Security Reports
+
+To submit sensitive security reports or findings, [contact the cFS Product Team](README.md#contact-the-cfs-product-team).
+
 ## Testing
 
-**Disclaimer: nasa/cFS is not responsible for any liability incurred under the [Apache License 2.0](https://github.com/nasa/cFS/blob/main/LICENSE).**
+**Disclaimer: nasa/cFS is not responsible for any liability incurred as stated under the [Apache License 2.0](https://github.com/nasa/cFS/blob/main/LICENSE).**
 
 Testing is an important aspect our team values to improve the cFS bundle. Several tools are used for testing:
 
 ### CodeQL
 
-The [cFS CodeQL GitHub Actions workflow](https://github.com/nasa/cFS/actions/workflows/codeql-build.yml) is available to the public. To review the results, fork the cFS repository and run the CodeQL workflow. 
+The [cFS CodeQL GitHub Actions workflow](https://github.com/nasa/cFS/actions/workflows/codeql-build.yml) is available to the public. To review the results, fork the cFS repository and run the CodeQL workflow.
 
-CodeQL is ran for every push and pull-request on all branches of cFS in GitHub Actions. 
+CodeQL is ran for every push and pull-request on all branches of cFS in GitHub Actions.
 
-For the CodeQL GitHub Actions setup, visit https://github.com/github/codeql-action. 
+For the CodeQL GitHub Actions setup, visit https://github.com/github/codeql-action.
 
 ### LGTM
 
-LGTM [results](https://lgtm.com/projects/g/nasa/cFS?mode=list) are available to the public. Since suppression comments are not used, many warnings and errors may not be accurate. Therefore, the results may contain false positives and other inapplicable warnings and errors. 
+LGTM [results](https://lgtm.com/projects/g/nasa/cFS?mode=list) are available to the public. Since suppression comments are not used, many warnings and errors may not be accurate. Therefore, the results may contain false positives and other inapplicable warnings and errors.
 
 LGTM is ran for every pull-request on all branches of cFS.
 
@@ -30,36 +34,32 @@ For more information about LGTM, visit https://lgtm.com/.
 
 ### Cppcheck
 
-The [cFS Cppcheck GitHub Actions workflow and results](https://github.com/nasa/cFS/actions/workflows/static-analysis.yml) are available to the public. To view the results, select a workflow and download the artifacts. 
+The [cFS Cppcheck GitHub Actions workflow and results](https://github.com/nasa/cFS/actions/workflows/static-analysis.yml) are available to the public. To view the results, select a workflow and download the artifacts.
 
-Cppcheck is ran for every push on the main branch and every pull request on all branches of cFS in Github Actions. 
+Cppcheck is ran for every push on the main branch and every pull request on all branches of cFS in Github Actions.
 
 For more information about Cppcheck, visit http://cppcheck.sourceforge.net/.
 
 ### CodeSonar
 
-CodeSonar results are not available to the public. 
+CodeSonar results are not available to the public.
 
 CodeSonar is typically ran on a “once per release” sort of schedule.  
 
-For more information about CodeSonar, visit https://www.grammatech.com/codesonar-cc. 
+For more information about CodeSonar, visit https://www.grammatech.com/codesonar-cc.
 
 ### Fuzz Testing
 
 The application used to fuzz test cFS and its results are not available to the public.
 
-The latest version of cFS is fuzzed nightly using a continuous integration pipeline. 
+The latest version of cFS is fuzzed nightly using a continuous integration pipeline.
 
-For more information about AFL used by the Fuzzing cFS application, visit https://github.com/google/AFL. 
-
-## Security Reports
-
-To submit security reports or findings, email us at cfs-program@lists.nasa.gov.
+For more information about AFL used by the Fuzzing cFS application, visit https://github.com/google/AFL.
 
 ## Additional Support
 
-For additional support, submit a GitHub issue. You can also email the cfs community at cfs-community@lists.nasa.gov. 
+For additional support, submit a GitHub issue.
 
-You can subscribe to the mailing list [here](https://lists.nasa.gov/mailman/listinfo/cfs-community) that includes all the community members/users of the NASA core Flight Software (cFS) product line. The mailing list is used to communicate any information related to the cFS product such as current releases, bug findings and fixes, enhancement requests, community meeting notifications, sending out meeting minutes, etc.
+You can also [join the cfs community mailing list](README.md#join-the-mailing-list) for technical discussions with cFS developers and users.
 
 If you wish to report a cybersecurity incident or concern, please contact the NASA Security Operations Center either by phone at 1-877-627-2732 or via email address soc@nasa.gov.


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #257 

The mailing list system migrated to a new server resulting in a new subscription process.

**Testing performed**
Tested subscription method from separate personal emails. 

Users should receive an email looking like the screenshot below upon subscription.

---------------------------------------

![cFS-community_confirmation_email](https://user-images.githubusercontent.com/59618057/118673958-6d983a80-b7c7-11eb-91b3-9dd74d17fd35.png)

---------------------------------------

**Expected behavior changes**
No behavior changes on cFS codebase

**System(s) tested on**
n/a

**Additional context**
Streamlined subscription method, new system only requires a single email interaction as opposed to a request/approve/confirm loop

**Code contributions**
None