### PR TITLE
Fix #261, Use Full Path for Queries in CodeQL

### DIFF
--- a/.github/codeql/codeql-coding-standard.yml
+++ b/.github/codeql/codeql-coding-standard.yml
@@ -1,0 +1,19 @@
+name: "CodeQL Coding Standard Configuration File"
+
+disable-default-queries: true
+
+queries:
+  - name: JPL Rules
+    uses: github/codeql/cpp/ql/src/JPL_C@main
+  - name: MISRA Rule 9-5-1
+    uses: github/codeql/cpp/ql/src/jsf/4.20 Unions and Bit Fields/AV Rule 153.ql@main
+  - name: MISRA Rule 5-18-1
+    uses: github/codeql/cpp/ql/src/jsf/4.21 Operators/AV Rule 168.ql@main
+  - name: MISRA 6-2-2
+    uses: github/codeql/cpp/ql/src/jsf/4.25 Expressions/AV Rule 202.ql@main
+  - name: MISRA Rule 5-14-1
+    uses: github/codeql/cpp/ql/src/jsf/4.21 Operators/AV Rule 165.ql@main
+  - name: MISRA Rule 5-3-2
+    uses: github/codeql/cpp/ql/src/jsf/4.21 Operators/AV Rule 165.ql@main
+  - name: MISRA Rule 7-5-2
+    uses: github/codeql/cpp/ql/src/jsf/4.22 Pointers and References/AV Rule 173.ql@main


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #261 
Use the full path of queries in CodeQL so repositories using the cFS configuration files will run CodeQL. Need to be integrated so CodeQL workflows runs with no errors. 

**Testing performed**
Tested locally in ArielSAdams/cFS@testpr

**Expected behavior changes**
Repositories such as PSP will run CodeQL with no errors. 
 
**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal
