### PR TITLE
Fix #272, Apply fix for Osal guide pdf generation

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -221,7 +221,7 @@ jobs:
         if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
         run: |
           mkdir deploy
-          cd ./build/docs/osalguide/latex
+          cd ./build/docs/osalguide/apiguide/latex
           make > build.txt
           mv refman.pdf $GITHUB_WORKSPACE/deploy/OSAL_Users_Guide.pdf
           # Could add pandoc and convert to github markdown


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Modified build-documentation.yml to fix #272 and successfully generate the Osal guide pdf in the documentation GitHub Actions workflow

**Testing performed**
Steps taken to test the contribution:
1. Modified the if statements in build-documentation.yml to force the Osal pdf to generate on my forked branch to ensure the fix worked properly. The output of this GitHub Actions Documentation workflow run is [here](https://github.com/nmullane/cFS/actions/runs/961655019)
2. The change to the if statements was reverted and a GitHub Actions Documentation worfklow run without this modification is [here](https://github.com/nmullane/cFS/actions/runs/961672984) 

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 -  Changed a single `cd` command in build-documentation.yml which should let the subsequent `make` call run properly
 - No expected behavior should change. This only fixes an issue with the Osal guide not being generated by GitHub Actions.

**System(s) tested on**
 - GitHub actions ubuntu-18.04 runner

**Code contributions**
The cFS repository is provided to bundle the cFS Framework.  It is utilized for bundling submodules, continuous integration testing, and version management and does not contain any software.  Code contributions should be directed to the appropriate submodule.

**Contributor Info - All information REQUIRED for consideration of pull request**
Niall Mullane, GSFC Code 582 intern