### PR TITLE
Fix #286, Documentation Duplicate Check

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -71,9 +71,9 @@ jobs:
           fi
 
   build-usersguide:
-    # Name the Job
     needs: checks-for-duplicates
     if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' }}
+    # Name the Job
     name: Users Guide
     # Set the type of machine to run on
     runs-on: ubuntu-18.04
@@ -92,7 +92,7 @@ jobs:
           cp ./cfe/cmake/Makefile.sample Makefile
           cp -r ./cfe/cmake/sample_defs sample_defs
 
-      # Setup the build system
+      # Setup the build system   
       - name: Make Prep
         run: make prep
 
@@ -113,7 +113,6 @@ jobs:
             make_usersguide_stderr.txt
             usersguide_warnings.log
 
-
       - name: Error Check
         run: |
           if [[ -s make_usersguide_stderr.txt ]]; then
@@ -128,6 +127,15 @@ jobs:
             exit -1
           fi
 
+  pdf-usersguide:  
+    needs: build-usersguide
+    # Name the Job
+    name: PDF Users Guide
+    # Set the type of machine to run on
+    runs-on: ubuntu-18.04
+
+    steps:
+    
       - name: PDF generation installs
         if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
         run: |
@@ -155,9 +163,9 @@ jobs:
           SINGLE_COMMIT: true
 
   build-osalguide:
-    # Name the Job
     needs: checks-for-duplicates
     if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' }}
+    # Name the Job
     name: Osal Guide
     # Set the type of machine to run on
     runs-on: ubuntu-18.04
@@ -176,7 +184,7 @@ jobs:
           cp ./cfe/cmake/Makefile.sample Makefile
           cp -r ./cfe/cmake/sample_defs sample_defs
 
-      # Setup the build system
+      # Setup the build system 
       - name: Make Prep
         run: make prep
 
@@ -188,7 +196,6 @@ jobs:
           make osalguide > make_osalguide_stdout.txt 2> make_osalguide_stderr.txt
           mv build/doc/osalguide/osal-apiguide-warnings.log osal-apiguide-warnings.log
 
-
       - name: Archive Osal Guide Build Logs
         uses: actions/upload-artifact@v2
         with:
@@ -197,7 +204,6 @@ jobs:
             make_osalguide_stdout.txt
             make_osalguide_stderr.txt
             osal-apiguide-warnings.log
-
 
       - name: Error Check
         run: |
@@ -213,6 +219,13 @@ jobs:
             exit -1
           fi
 
+  pdf-osalguide:    
+    needs: build-osalguide
+    # Name the Job
+    name: PDF Osal Guide
+    # Set the type of machine to run on
+    runs-on: ubuntu-18.04
+    steps:
       - name: PDF generation installs
         if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
         run: |


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
Fixes #286.
Used with https://github.com/nasa/cFS/pull/273. 
Skips individual steps for the OSAL and cFE jobs. Does not skip the last three steps that generates the PDFs. 

**Testing performed**
Tested locally on forked repo. PDFs were updated in gh-pages branch. 
![image](https://user-images.githubusercontent.com/69638935/124638508-a7dd9a00-de50-11eb-8c79-ca8f88e13213.png)

**Expected behavior changes**
The documentation workflow should generate and update the cFE and OSAL User Guides. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal