### PR TITLE
Fix #298, Run Documentation and Guides on Push

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           concurrent_skipping: 'same_content'
           skip_after_successful_duplicate: 'true'
-          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+          do_not_skip: '["push", "workflow_dispatch", "schedule"]'
 
   build-docs:
     #Continue if checks-for-duplicates found no duplicates. Always runs for pull-requests.


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #298 
PDFs only generates on push for main branch. Workflow will run on push rather than pull request. 

**Testing performed**
Tested on fork.
![image](https://user-images.githubusercontent.com/69638935/125629051-edcd19ed-970e-4a01-ad67-b1781331068c.png)

**Expected behavior changes**
PDFs will generate.

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal 
