### PR TITLE
Fix #264, CodeQL Dependent on a Successful Build

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -1,16 +1,19 @@
 name: "CodeQL Analysis"
 
+# Only trigger, when the build workflow succeeded
 on:
-  push:
-  pull_request:
-    branches:
-      - main
-
+  workflow_run:
+    workflows: ["Build, Test, and Run \\[OMIT_DEPRECATED=true\\]"]
+    types:
+      - completed
+    branches: 
+      - '**'
 env:
   SIMULATION: native
   ENABLE_UNIT_TESTS: true
   OMIT_DEPRECATED: true
   BUILDTYPE: release
+
 
 jobs:
   #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
@@ -19,6 +22,7 @@ jobs:
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
@@ -117,7 +121,7 @@ jobs:
         run: |
           cp ./cfe/cmake/Makefile.sample Makefile
           cp -r ./cfe/cmake/sample_defs sample_defs
-
+ 
       # Setup the build system
       - name: Make Install
         if: ${{ !steps.skip-workflow.outputs.skip }}
@@ -127,3 +131,10 @@ jobs:
       - name: Perform CodeQL Analysis
         if: ${{ !steps.skip-workflow.outputs.skip }}
         uses: github/codeql-action/analyze@v1
+        
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Fail workflow
+        run: exit 1


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #264 
Added workflow_run event as a trigger. 

**Testing performed**
Tested on fork. Triggered on workflow_run. Will work once workflow is integrated in main. 
![image](https://user-images.githubusercontent.com/69638935/126205571-5242209a-234a-4e49-9c56-9fbdc02c611a.png)

**Expected behavior changes**
If Build, Test, and Run [OMIT_DEPRECATED=true] fails, then CodeQL will not run. 

**Additional context**
https://stackoverflow.com/questions/62750603/github-actions-trigger-another-action-after-one-action-is-completed
Build, Test, and Run [OMIT_DEPRECATED=true] must be renamed. 

Tried 

```
    workflows: 
      - 'Build, Test, and Run [OMIT_DEPRECATED=true]'
```

```
    workflows: 
      - Build, Test, and Run [OMIT_DEPRECATED=true]
```

```
    workflows: ["Build, Test, and Run [OMIT_DEPRECATED=true]"]
```

Build, Test, and Run name works. 

Downside is that CodeQL workflow does not name what triggered the workflow such as the name of the commit. Instead it always says the name of the workflow which is CodeQL Analysis.

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal 
