### PR TITLE
Fix #322, Add Discussions in the Contributing Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,9 @@ This project and everyone participating in it is governed by the [cFS Code of Co
 
 ### Discussions and Questions
 
-For questions or help, submit a GitHub issue, [join the cfs community mailing list](README.md#join-the-mailing-list).
+For discussions, questions, or ideas, [start a new discussion](https://github.com/nasa/cFS/discussions/new) in the cFS repository under the Discussions tab. 
+
+[Join the cfs community mailing list](README.md#join-the-mailing-list).
 
 
 ### Report Bugs

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ See related repositories for current open issues.
 
 ## Getting Help
 
-For best results, submit issues:questions or issues:help wanted requests to this repo.
+### Discussions 
 
+You can [start a new discussion](https://github.com/nasa/cFS/discussions/new) for discussions, questions, or ideas, in the cFS repository under the Discussions tab.
 
 ### Join the mailing list
 
@@ -85,7 +86,6 @@ If you'd like to unsubscribe, send an email with the word *unsubscribe* to cfs-c
 ### Contact the cFS Product Team
 
 You can email the cFS Product Team at cfs-program@lists.nasa.gov to explore partnerships and other arrangements for in-depth support.
-
 
 ## Setup
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #322 
Add information on where to submit discussions, questions, and ideas. 

**Expected behavior changes**
Users should know to submit discussions, questions, and ideas in the Discussions tab of the cFS repository instead of creating an issue.

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal 
