### PR TITLE
Fix #301, Add Github workflows to bootes.x

### DIFF
--- a/.github/codeql/codeql-coding-standard.yml
+++ b/.github/codeql/codeql-coding-standard.yml
@@ -1,0 +1,19 @@
+name: "CodeQL Coding Standard Configuration File"
+
+disable-default-queries: true
+
+queries:
+  - name: JPL Rules
+    uses: github/codeql/cpp/ql/src/JPL_C@main
+  - name: MISRA Rule 9-5-1
+    uses: github/codeql/cpp/ql/src/jsf/4.20 Unions and Bit Fields/AV Rule 153.ql@main
+  - name: MISRA Rule 5-18-1
+    uses: github/codeql/cpp/ql/src/jsf/4.21 Operators/AV Rule 168.ql@main
+  - name: MISRA 6-2-2
+    uses: github/codeql/cpp/ql/src/jsf/4.25 Expressions/AV Rule 202.ql@main
+  - name: MISRA Rule 5-14-1
+    uses: github/codeql/cpp/ql/src/jsf/4.21 Operators/AV Rule 165.ql@main
+  - name: MISRA Rule 5-3-2
+    uses: github/codeql/cpp/ql/src/jsf/4.21 Operators/AV Rule 165.ql@main
+  - name: MISRA Rule 7-5-2
+    uses: github/codeql/cpp/ql/src/jsf/4.22 Pointers and References/AV Rule 173.ql@main

--- a/.github/codeql/codeql-security.yml
+++ b/.github/codeql/codeql-security.yml
@@ -1,0 +1,7 @@
+name: "CodeQL Security Configuration File"
+
+queries:
+  - name: Security and Quality
+    uses: security-and-quality
+  - name: Security Extended
+    uses: security-extended 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,63 @@
+# Our Workflows
+
+## Deprecated Build, Test, and Run
+[![Deprecated Build, Test, and Run](https://github.com/nasa/cfs/actions/workflows/build-cfs-deprecated.yml/badge.svg?branch=bootes.x)](https://github.com/nasa/cfs/actions/workflows/build-cfs-deprecated.yml)
+
+This action builds, tests, and runs the cFS bundle using deprecated code. The flag OMIT_DEPRECATED is set to false. For more information on the OMIT_DEPRECATED flag, see [global_build_options.cmake](https://github.com/nasa/cFE/blob/063b4d8a9c4a7e822af5f3e4017599159b985bb0/cmake/sample_defs/global_build_options.cmake). 
+
+Build, Test, and Run runs for every push and every pull request on all branches of cFS in Github Actions.
+
+## Build, Test, and Run [OMIT_DEPRECATED=true]
+[![Build, Test, and Run %5B OMIT_DEPRECATED=true %5B](https://github.com/nasa/cFS/actions/workflows/build-cfs.yml/badge.svg?branch=bootes.x)](https://github.com/nasa/cFS/actions/workflows/build-cfs.yml)
+
+This action builds, tests, and runs the cFS bundle omitting deprecated code.
+
+Build, Test, and Run [OMIT_DEPRECATED=true] runs for every push and every pull request on all branches of cFS in Github Actions. For more information on the OMIT_DEPRECATED flag, see [global_build_options.cmake](https://github.com/nasa/cFE/blob/063b4d8a9c4a7e822af5f3e4017599159b985bb0/cmake/sample_defs/global_build_options.cmake). 
+
+## CodeQL Analysis
+[![CodeQL Analaysis](https://github.com/nasa/cfs/actions/workflows/codeql-build.yml/badge.svg?branch=bootes.x)](https://github.com/nasa/cfs/actions/workflows/codeql-build.yml)
+
+This action runs GitHub's static analysis engine, CodeQL, against our repository's source code to find security vulnerabilities. It then automatically uploads the results to GitHub so they can be displayed in the repository's code scanning alerts found under the security tab. CodeQL runs an extensible set of [queries](https://github.com/github/codeql), which have been developed by the community and the [GitHub Security Lab](https://securitylab.github.com/) to find common vulnerabilities in your code.
+
+CodeQL runs for every push and pull-request on all branches of cFS in GitHub Actions.
+
+For the CodeQL GitHub Actions setup, visit https://github.com/github/codeql-action.
+
+Our CodeQL action uses a configuration file to use specific queries, which can be found at [.github/codeql](https://github.com/nasa/cFS/tree/main/.github/codeql).
+
+## Static Analaysis
+[![Static Analaysis](https://github.com/nasa/cfs/actions/workflows/static-analysis.yml/badge.svg?branch=bootes.x)](https://github.com/nasa/cfs/actions/workflows/static-analysis.yml)
+
+This action runs a static analysis tool for C/C++ code known as cppcheck. Cppcheck is designed to be able to analyze C/C++ code even if it has non-standard syntax, which is common in embedded projects.
+
+The cFS Cppcheck GitHub Actions workflow and results are available to the public. To view the results, select a workflow and download the artifacts.
+
+Cppcheck runs for every push on the main branch and every pull request on all branches of cFS in Github Actions.
+
+For more information about Cppcheck, visit http://cppcheck.sourceforge.net/.
+
+## Local Unit Test
+[![Local Unit Test](https://github.com/nasa/osal/actions/workflows/local_unit_test.yml/badge.svg?branch=bootes.x)](https://github.com/nasa/osal/actions/workflows/local_unit_test.yml)
+
+This action tests our code using GCC's coverage testing tool gcov.
+
+Local Unit Test runs for every push and every pull request on all branches of cFS in Github Actions.
+
+## Documentation and Guides
+[![Documentation and Guides](https://github.com/nasa/cfs/actions/workflows/build-documentation.yml/badge.svg?branch=bootes.x)](https://github.com/nasa/cfs/actions/workflows/build-documentation.yml)
+
+This action creates doxygen documents for cFE, cFS users guide, and osal guide.
+
+Documentation and Guides runs for every push and every pull request on all branches of cFS in Github Actions. The workflow pushes the PDFs for every push on the main branch. The PDFs can be found at https://github.com/nasa/cfs/tree/gh-pages. 
+
+## Changelog
+[![Changelog](https://github.com/nasa/cfs/actions/workflows/changelog.yml/badge.svg?branch=bootes.x)](https://github.com/nasa/cfs/actions/workflows/changelog.yml)
+
+This action creates a changelog file which documents all the issues in cFS.
+
+The Changelog action runs manually. 
+
+## Format Check
+[![Format Check](https://github.com/nasa/osal/actions/workflows/format-check.yml/badge.svg?branch=bootes.x)](https://github.com/nasa/osal/actions/workflows/format-check.yml)
+
+This action uses [clang-format-10](https://github.com/nasa/cFS/blob/main/.clang-format) to check for format errors.

--- a/.github/workflows/build-cfs-deprecated.yml
+++ b/.github/workflows/build-cfs-deprecated.yml
@@ -1,0 +1,166 @@
+name: "Deprecated Build, Test, and Run"
+
+# Run every time a new commit pushed or for pull requests
+on:
+  push:
+  pull_request:
+
+env:
+  SIMULATION: native
+  OMIT_DEPRECATED: false
+
+jobs:
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  check-for-duplicates:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+        should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+          
+  # Set the job key. The key is displayed as the job name
+  # when a job name is not provided
+
+  build-cfs:
+    #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
+    needs: check-for-duplicates
+    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
+    name: Build
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        buildtype: [debug, release]
+
+    # Set the type of machine to run on
+    env:
+      BUILDTYPE: ${{ matrix.buildtype }}
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          ref: bootes.x
+
+      # Setup the build system
+      - name: Copy Files
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make Prep
+        run: make prep
+
+      - name: Make
+        run: make
+
+  test-cfs:
+    name: Test
+    needs: build-cfs
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        buildtype: [debug, release]
+
+    # Set the type of machine to run on
+    env:
+      BUILDTYPE: ${{ matrix.buildtype }}
+      ENABLE_UNIT_TESTS: true
+
+
+    steps:
+      - name: Install Dependencies
+        run: sudo apt-get install lcov -y
+
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          ref: bootes.x
+
+      # Setup the build system
+      - name: Copy Files
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make
+        run: make
+
+      - name: Run Tests
+        run: make test
+
+      - name: Check Coverage
+        run: make lcov
+
+  run-cfs:
+    name: Run
+    needs: build-cfs
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        buildtype: [debug, release]
+
+    # Set the type of machine to run on
+    env:
+      BUILDTYPE: ${{ matrix.buildtype }}
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          ref: bootes.x
+
+      # Setup the build system
+      - name: Copy sample_defs
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make Install
+        run: make install
+
+      - name: List cpu1
+        run: ls build/exe/cpu1/
+
+      - name: Run cFS
+        run: |
+          ./core-cpu1 > cFS_startup_cpu1.txt &
+          sleep 30
+          ../host/cmdUtil --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
+        working-directory: ./build/exe/cpu1/
+
+      - name: Archive cFS Startup Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: cFS-startup-log-deprecated-false-${{ matrix.buildtype }}
+          path: ./build/exe/cpu1/cFS_startup_cpu1.txt
+
+      - name: Check for cFS Warnings
+        run: |
+          if [[ -n $(grep -i "warn\|err\|fail" cFS_startup_cpu1.txt) ]]; then
+                  echo "Must resolve warn|err|fail in cFS startup before submitting a pull request"
+                  echo ""
+                  grep -i 'warn\|err\|fail' cFS_startup_cpu1.txt
+                  exit -1
+          fi
+        working-directory: ./build/exe/cpu1/

--- a/.github/workflows/build-cfs.yml
+++ b/.github/workflows/build-cfs.yml
@@ -1,0 +1,164 @@
+name: Build, Test, and Run [OMIT_DEPRECATED=true]
+
+# Run every time a new commit pushed or for pull requests
+on:
+  push:
+  pull_request:
+
+env:
+  SIMULATION: native
+  OMIT_DEPRECATED: true
+
+jobs:
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  check-for-duplicates:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+        should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+          
+  build-cfs:
+    #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
+    needs: check-for-duplicates
+    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
+    name: Build
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        buildtype: [debug, release]
+
+    # Set the type of machine to run on
+    env:
+      BUILDTYPE: ${{ matrix.buildtype }}
+
+    steps:
+      # Check out the cfs bundle
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          ref: bootes.x
+
+      # Setup the build system
+      - name: Copy Files
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make Prep
+        run: make prep
+
+      - name: Make
+        run: make
+
+  test-cfs:
+    name: Test
+    runs-on: ubuntu-18.04
+
+    needs: build-cfs
+
+    strategy:
+      fail-fast: false
+      matrix:
+        buildtype: [debug, release]
+
+    # Set the type of machine to run on
+    env:
+      BUILDTYPE: ${{ matrix.buildtype }}
+      ENABLE_UNIT_TESTS: true
+
+
+    steps:
+      - name: Install Dependencies
+        run: sudo apt-get install lcov -y
+
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          ref: bootes.x
+
+      # Setup the build system
+      - name: Copy Files
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make
+        run: make
+
+      - name: Run Tests
+        run: make test
+
+      - name: Check Coverage
+        run: make lcov
+
+  run-cfs:
+    name: Run
+    needs: build-cfs
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        buildtype: [debug, release]
+
+    # Set the type of machine to run on
+    env:
+      BUILDTYPE: ${{ matrix.buildtype }}
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          ref: bootes.x
+
+      # Setup the build system
+      - name: Copy sample_defs
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make Install
+        run: make install
+
+      - name: List cpu1
+        run: ls build/exe/cpu1/
+
+      - name: Run cFS
+        run: |
+          ./core-cpu1 > cFS_startup_cpu1.txt &
+          sleep 30
+          ../host/cmdUtil --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
+        working-directory: ./build/exe/cpu1/
+
+      - name: Archive cFS Startup Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: cFS-startup-log-deprecate-true-${{ matrix.buildtype }}
+          path: ./build/exe/cpu1/cFS_startup_cpu1.txt
+
+      - name: Check for cFS Warnings
+        run: |
+          if [[ -n $(grep -i "warn\|err\|fail" cFS_startup_cpu1.txt) ]]; then
+                  echo "Must resolve warn|err|fail in cFS startup before submitting a pull request"
+                  echo ""
+                  grep -i 'warn\|err\|fail' cFS_startup_cpu1.txt
+                  exit -1
+          fi
+        working-directory: ./build/exe/cpu1/

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -1,0 +1,254 @@
+name: Documentation and Guides
+
+# Run every time a new commit pushed to main or for pull requests
+on:
+  push:
+  pull_request:
+
+env:
+  SIMULATION: native
+
+jobs:
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action.
+  checks-for-duplicates:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
+  build-docs:
+    #Continue if checks-for-duplicates found no duplicates. Always runs for pull-requests.
+    needs: checks-for-duplicates
+    if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' }}
+    name: cFE Documentation
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Install Dependencies
+        run: sudo apt-get install doxygen graphviz -y
+
+        # Check out the cfs bundle
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          ref: bootes.x
+
+      # Prepare build "recipes"
+      - name: Copy Files
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make Prep
+        run: make prep
+
+      - name: Build Docs
+        run: |
+          make doc > make_doc_stdout.txt 2> make_doc_stderr.txt
+
+      # Upload documentation logs as artifacts
+      - name: Archive Documentation Build Logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: cFS Docs Artifacts
+          path: |
+            make_doc_stdout.txt
+            make_doc_stderr.txt
+
+      - name: Error Check
+        run: |
+          if [[ -s make_doc_stderr.txt ]]; then
+            cat make_doc_stderr.txt
+            exit -1
+          fi
+
+  build-usersguide:
+    needs: checks-for-duplicates
+    if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' }}
+    # Name the Job
+    name: Users Guide
+    # Set the type of machine to run on
+    runs-on: ubuntu-18.04
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          persist-credentials: false
+          ref: bootes.x
+
+      # Setup the build system
+      - name: Copy Files
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system   
+      - name: Make Prep
+        run: make prep
+
+      - name: Install Dependencies
+        run: sudo apt-get install doxygen graphviz -y
+
+      - name: Build Usersguide
+        run: |
+          make usersguide > make_usersguide_stdout.txt 2> make_usersguide_stderr.txt
+
+      - name: Archive Users Guide Build Logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: Users Guide Artifacts
+          path: |
+            make_usersguide_stdout.txt
+            make_usersguide_stderr.txt
+            cfe-usersguide-warnings.log
+
+      - name: Error Check
+        run: |
+          if [[ -s make_usersguide_stderr.txt ]]; then
+            cat make_usersguide_stderr.txt
+            exit -1
+          fi
+
+      - name: Warning Check
+        run: |
+          if [[ -s cfe-usersguide-warnings.log ]]; then
+            cat cfe-usersguide-warnings.log
+            exit -1
+          fi
+
+  pdf-usersguide:  
+    needs: build-usersguide
+    # Name the Job
+    name: PDF Users Guide
+    # Set the type of machine to run on
+    runs-on: ubuntu-18.04
+
+    steps:
+    
+      - name: PDF generation installs
+        if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
+        run: |
+          sudo apt-get install texlive-latex-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra
+
+      - name: PDF generation
+        if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
+        run: |
+          set -x
+          mkdir deploy
+          cd ./build/docs/users_guide/latex
+          make > build.txt
+          mv refman.pdf $GITHUB_WORKSPACE/deploy/cFE_Users_Guide.pdf
+          # Could add pandoc and convert to github markdown
+          # pandoc CFE_Users_Guide.pdf -t gfm
+
+      - name: Deploy
+        if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: deploy
+          CLEAN: false
+          SINGLE_COMMIT: true
+
+  build-osalguide:
+    needs: checks-for-duplicates
+    if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' }}
+    # Name the Job
+    name: Osal Guide
+    # Set the type of machine to run on
+    runs-on: ubuntu-18.04
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          persist-credentials: false
+          ref: bootes.x
+
+      # Setup the build system
+      - name: Copy Files
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system 
+      - name: Make Prep
+        run: make prep
+
+      - name: Install Dependencies
+        run: sudo apt-get install doxygen graphviz -y
+
+      - name: Build OSAL Guide
+        run: |
+          make osalguide > make_osalguide_stdout.txt 2> make_osalguide_stderr.txt
+          mv build/doc/warnings.log osal-apiguide-warnings.log
+
+      - name: Archive Osal Guide Build Logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: OSAL Guide Artifacts
+          path: |
+            make_osalguide_stdout.txt
+            make_osalguide_stderr.txt
+            osal-apiguide-warnings.log
+
+      - name: Error Check
+        run: |
+          if [[ -s make_osalguide_stderr.txt ]]; then
+            cat make_osalguide_stderr.txt
+            exit -1
+          fi
+
+      - name: Warning Check
+        run: |
+          if [[ -s osal-apiguide-warnings.log ]]; then
+            cat osal-apiguide-warnings.log
+            exit -1
+          fi
+
+  pdf-osalguide:    
+    needs: build-osalguide
+    # Name the Job
+    name: PDF Osal Guide
+    # Set the type of machine to run on
+    runs-on: ubuntu-18.04
+    steps:
+      - name: PDF generation installs
+        if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
+        run: |
+          sudo apt-get install texlive-latex-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra
+
+      - name: PDF generation
+        if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
+        run: |
+          mkdir deploy
+          cd ./build/docs/osalguide/apiguide/latex
+          make > build.txt
+          mv refman.pdf $GITHUB_WORKSPACE/deploy/OSAL_Users_Guide.pdf
+          # Could add pandoc and convert to github markdown
+          # pandoc CFE_Users_Guide.pdf -t gfm
+
+      - name: Deploy
+        if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: deploy
+          CLEAN: false
+          SINGLE_COMMIT: true

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,34 @@
+name: Changelog
+
+# Controls when the action will run. 
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Run Changelog
+        uses: heinrichreimer/github-changelog-generator-action@v2.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issuesLabel: "### Closed issues" 
+          breakingLabel: "### Breaking changes" 
+          enhancementLabel: "### Implemented enhancements" 
+          bugsLabel: "### Fixed bugs" 
+          deprecatedLabel: "### Deprecated" 
+          removedLabel: "### Removed" 
+          securityLabel: "### Security fixes"
+          pullRequests: false
+          author: false
+        
+      - name: "Upload changelog"
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: "Changelog"
+          path: CHANGELOG.md
+          

--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -1,0 +1,132 @@
+name: "CodeQL Analysis"
+
+on:
+  push:
+  pull_request:
+   branches:
+    - bootes.x
+
+env:
+  SIMULATION: native
+  ENABLE_UNIT_TESTS: true
+  OMIT_DEPRECATED: true
+  BUILDTYPE: release
+
+jobs:
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  check-for-duplicates:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
+      
+  CodeQL-Security-Build:
+    #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
+    needs: check-for-duplicates
+    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-18.04
+    timeout-minutes: 15
+
+    steps:
+      # Checks out a copy of your repository
+      - name: Checkout code
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        uses: actions/checkout@v2
+        with:
+          repository: nasa/cFS
+          submodules: true
+          ref: bootes.x
+
+      - name: Check versions
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        run: |
+           git log -1 --pretty=oneline
+           git submodule
+
+      - name: Initialize CodeQL
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        uses: github/codeql-action/init@v1
+        with:
+          languages: c
+          config-file: ./.github/codeql/codeql-security.yml
+
+      # Setup the build system
+      - name: Copy sample_defs
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make Install
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        run: make
+
+      # Run CodeQL
+      - name: Perform CodeQL Analysis
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        uses: github/codeql-action/analyze@v1
+
+  CodeQL-Coding-Standard-Build:
+    #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
+    needs: check-for-duplicates
+    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-18.04
+    timeout-minutes: 15
+
+    steps:
+      # Checks out a copy of your repository
+      - name: Checkout code
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        uses: actions/checkout@v2
+        with:
+          repository: nasa/cFS
+          submodules: true
+          ref: bootes.x
+
+      - name: Check versions
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        run: |
+           git log -1 --pretty=oneline
+           git submodule
+
+      - name: Checkout codeql code      
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        uses: actions/checkout@v2
+        with:
+          repository: github/codeql 
+          submodules: true 
+          path: codeql
+          ref: bootes.x
+
+      - name: Initialize CodeQL
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        uses: github/codeql-action/init@v1
+        with:
+          languages: c
+          config-file: ./.github/codeql/codeql-coding-standard.yml
+
+      # Setup the build system
+      - name: Copy sample_defs
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      # Setup the build system
+      - name: Make Install
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        run: make
+
+      # Run CodeQL
+      - name: Perform CodeQL Analysis
+        if: ${{ !steps.skip-workflow.outputs.skip }}
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,82 @@
+name: Static Analysis
+
+# Run this workflow every time a new commit pushed to your repository and for pull requests
+on:
+  push:
+  pull_request:
+
+jobs:
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  check-for-duplicates:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+        should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
+  static-analysis:
+    #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
+    needs: check-for-duplicates
+    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
+    name: Run cppcheck
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        cppcheck: [bundle, cfe, osal, psp]
+
+    steps:      
+      - name: Install cppcheck
+        run: sudo apt-get install cppcheck -y
+
+        # Checks out a copy of the cfs bundle
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          ref: bootes.x
+
+      - name: Run bundle cppcheck
+        if: ${{matrix.cppcheck =='bundle'}}
+        run: cppcheck --force --inline-suppr --quiet . 2> ${{matrix.cppcheck}}_cppcheck_err.txt
+
+        # Run strict static analysis for embedded portions of cfe, osal, and psp
+      - name: cfe strict cppcheck
+        if: ${{matrix.cppcheck =='cfe'}}
+        run: |
+          cd ${{matrix.cppcheck}}
+          cppcheck --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./fsw/cfe-core/src/es ./fsw/cfe-core/src/evs ./fsw/cfe-core/src/fs ./fsw/cfe-core/src/inc ./fsw/cfe-core/src/sb ./fsw/cfe-core/src/tbl ./fsw/cfe-core/src/time  -UCFE_PLATFORM_TIME_CFG_CLIENT -DCFE_PLATFORM_TIME_CFG_SERVER 2> ../${{matrix.cppcheck}}_cppcheck_err.txt
+
+      - name: osal strict cppcheck
+        if: ${{matrix.cppcheck =='osal'}}
+        run: |
+          cd ${{matrix.cppcheck}}
+          cppcheck --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./src/bsp ./src/os 2> ../${{matrix.cppcheck}}_cppcheck_err.txt
+
+      - name: psp strict cppcheck
+        if: ${{matrix.cppcheck =='psp'}}
+        run: |
+          cd ${{matrix.cppcheck}}
+          cppcheck --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./fsw 2> ../${{matrix.cppcheck}}_cppcheck_err.txt
+
+      - name: Archive Static Analysis Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{matrix.cppcheck}}-cppcheck-err
+          path: ./*cppcheck_err.txt
+
+      - name: Check for errors
+        run: |
+          if [[ -s ${{matrix.cppcheck}}_cppcheck_err.txt ]];
+          then
+            cat ${{matrix.cppcheck}}_cppcheck_err.txt
+            exit -1
+          fi
+


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Redo of pull request #305 
- Added workflow directory and Codeql files for the Bootes build to fixes #301  .
- Modified  build-documentation.yml and static-analysis.yml to work with Bootes build.
- Modified the workflow README.md badges to work with bootes.x branch.


**Testing performed**
Steps taken to test the contribution:
1. Modified path for the build-documentation.yml build OSAL Guide so it could find the correct directory.
Documentation workflow [run](https://github.com/Frank393/cFS/actions/runs/1037623337)
2.  Modified path for the static-analysis.yml cfe strict cppcheck to find the correct directory.
Static analysis workflow [run](https://github.com/Frank393/cFS/actions/runs/1037623341)

**Expected behavior changes**

- With the added workflow and Codeql we can test the previous build with GitHub action and Codeql semantic code analyzer.

**System(s) tested on**
 - GitHub actions ubuntu-18.04 runner

**Contributor Info - All information REQUIRED for consideration of pull request**
Frank I. Gonzalez Soto , GSFC Code 582 intern
