### PR TITLE
Fix #331, Skip deploy job instead of step

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -153,11 +153,10 @@ jobs:
           key: usersguide-buildnum-${{ github.run_number }}
           
   deploy-usersguide:
-    needs: build-usersguide
-    # Name the Job
     name: Deploy Users Guide
-    # Set the type of machine to run on
     runs-on: ubuntu-18.04
+    needs: build-usersguide    
+    if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
 
     steps:
       - name: Cache cFS Build Environment for usersguide
@@ -258,6 +257,7 @@ jobs:
     needs: build-osalguide
     name: Deploy Osal Guide
     runs-on: ubuntu-18.04
+    if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
 
     steps:
       - name: Cache cFS Build Environment for osalguide
@@ -268,7 +268,6 @@ jobs:
           key: osalguide-buildnum-${{ github.run_number }}
           
       - name: Deploy to GitHub
-        if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -276,3 +275,4 @@ jobs:
           FOLDER: deploy
           CLEAN: false
           SINGLE_COMMIT: true
+          


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fix #331

**Testing performed**
Pushed to fork and check job skip in actions

**Expected behavior changes**
The Build Documentation workflow's deploy-usersguiude and deploy-osalguide **jobs** are skipped, see https://github.com/nasa/cFS/actions/runs/1106554863

**System(s) tested on**
GitHub CI

**Additional context**
None

