### PR TITLE
Fix #247, Move sample_libs into libraries dir

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,36 +9,36 @@
 [submodule "psp"]
 	path = psp
 	url = https://github.com/nasa/PSP.git
-        branch = master
+  branch = main
 [submodule "apps/ci_lab"]
 	path = apps/ci_lab
 	url = https://github.com/nasa/ci_lab.git
-        branch = master
+  branch = main
 [submodule "apps/sample_app"]
 	path = apps/sample_app
 	url = https://github.com/nasa/sample_app.git
-        branch = master
+	branch = main
 [submodule "apps/sample_lib"]
-	path = apps/sample_lib
+	path = libs/sample_lib
 	url = https://github.com/nasa/sample_lib.git
-        branch = master
+  branch = main
 [submodule "apps/sch_lab"]
 	path = apps/sch_lab
 	url = https://github.com/nasa/sch_lab.git
-        branch = master
+  branch = main
 [submodule "apps/to_lab"]
 	path = apps/to_lab
 	url = https://github.com/nasa/to_lab.git
-        branch = master
+  branch = main
 [submodule "tools/cFS-GroundSystem"]
 	path = tools/cFS-GroundSystem
 	url = https://github.com/nasa/cFS-GroundSystem.git
-        branch = master
+  branch = main
 [submodule "tools/elf2cfetbl"]
 	path = tools/elf2cfetbl
 	url = https://github.com/nasa/elf2cfetbl.git
-        branch = master
+  branch = main
 [submodule "tools/tblCRCTool"]
 	path = tools/tblCRCTool
 	url = https://github.com/nasa/tblCRCTool.git
-        branch = master
+  branch = main


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Creates a new directory "libs" at the cFS bundle level to put libraries in. This will create a little more clarity between applications and libraries

Fixes #247

**Testing performed**
CI Ubuntu

**Expected behavior changes**
None, everything should still compile

**System(s) tested on**
Ubuntu 18.04 

**Additional context**
Might require developers to fixup their local repos once change is merged