### PR TITLE
fix #376, "main" branch for cfe and osal submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "cfe"]
 	path = cfe
 	url = https://github.com/nasa/cFE.git
-	branch = master
+	branch = main
 [submodule "osal"]
 	path = osal
 	url = https://github.com/nasa/osal.git
-	branch = master
+	branch = main
 [submodule "psp"]
 	path = psp
 	url = https://github.com/nasa/PSP.git


### PR DESCRIPTION
**Describe the contribution**
Fixes #376, changes the branch declaration for the cfe and osal submodules to be "main".

**Testing performed**
git submodule init && git submodule update behave as expected.

**Expected behavior changes**
No impact to behavior.

**System(s) tested on**
Ubuntu 21.x

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov