### PR TITLE
Fix #447 #455, Deploy mission document from workflow by using reusable workflow

### DIFF
--- a/.github/workflows/build-deploy-doc.yml
+++ b/.github/workflows/build-deploy-doc.yml
@@ -1,0 +1,153 @@
+name: Build Document
+
+on:
+  workflow_call:
+    inputs:
+      # Required
+      target:
+        description: Document target name(s) as stringified JSON matrix list # Matrix example "[\"x\", \"y\"]"
+        type: string
+        required: true
+      # Optional
+      app-name:
+        description: Application name, leave blank if using cache
+        type: string
+        required: false
+        default: ''
+      cache-key:
+        description: Cache key to use
+        type: string
+        required: false
+        default: ''
+      buildpdf:
+        description: Build the PDF
+        type: boolean
+        required: false
+        default: true
+      deploy:
+        description: Deploy archived PDF to gh-pages
+        type: boolean
+        required: false
+        default: true
+
+jobs:
+  # Checks for duplicate actions. Skips push actions if there is a matching or
+  # duplicate pull-request action.
+  checks-for-duplicates:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["push", "workflow_dispatch", "schedule"]'
+
+  build-doc:
+    needs: checks-for-duplicates
+    if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' }}
+    name: Build Documentation
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(inputs.target) }}
+
+    steps:
+      - name: Get cache if supplied
+        id: cache-src-bld
+        if: ${{ inputs.cache-key != '' }}
+        uses: actions/cache@v2
+        with:
+          path: /home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/*
+          key: ${{ inputs.cache-key }}
+
+      - name: Checkout Bundle Main
+        if: ${{ inputs.app-name != '' }}
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          repository: nasa/cFS
+
+      - name: Checkout Repo
+        if: ${{ inputs.app-name != '' }}
+        uses: actions/checkout@v2
+        with:
+          path: apps/${{ inputs.app-name }}
+
+      - name: Copy Files
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+
+      - name: Add Repo To Build
+        if: ${{ inputs.app-name != '' }}
+        run: sed -i '/list(APPEND MISSION_GLOBAL_APPLIST/a list(APPEND MISSION_GLOBAL_APPLIST ${{ inputs.app-name }})' sample_defs/targets.cmake 
+
+      - name: Make Prep
+        run: make prep
+
+      - name: Install Doxygen Dependencies
+        run: sudo apt-get install doxygen graphviz -y
+
+      - name: Install PDF Generation Dependencies
+        if: ${{ inputs.buildpdf == true }}
+        run: |
+          sudo apt-get install texlive-latex-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra
+
+      - name: Build Document
+        run: |
+          make -C build ${{ matrix.target }} > ${{ matrix.target }}_stdout.txt 2> ${{ matrix.target }}_stderr.txt
+          mv build/docs/${{ matrix.target }}/${{ matrix.target }}-warnings.log .
+
+      - name: Archive Document Build Logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.target }}_doc_build_logs
+          path: |
+            ${{ matrix.target }}_stdout.txt
+            ${{ matrix.target }}_stderr.txt
+            ${{ matrix.target }}-warnings.log
+            
+      - name: Check For Document Build Errors
+        run: |
+          if [[ -s ${{ matrix.target }}_stderr.txt ]]; then
+            cat ${{ matrix.target }}_stderr.txt
+            exit -1
+          fi
+          
+      - name: Check For Document Warnings
+        run: |
+          if [[ -s ${{ matrix.target }}-warnings.log ]]; then
+            cat ${{ matrix.target }}-warnings.log
+            exit -1
+          fi
+          
+      - name: Generate PDF
+        if: ${{ inputs.buildpdf == true }}
+        run: |
+          make -C ./build/docs/${{ matrix.target }}/latex
+          mkdir deploy
+          mv ./build/docs/${{ matrix.target }}/latex/refman.pdf ./deploy/${{ matrix.target }}.pdf
+          # Could add pandoc and convert to github markdown
+          # pandoc ${{ matrix.target }}.pdf -t gfm
+
+      - name: Archive PDF
+        if: ${{ inputs.buildpdf == true }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.target }}_pdf
+          path: ./deploy/${{ matrix.target }}.pdf
+
+      - name: Deploy to GitHub
+        if: ${{ inputs.deploy == true }}
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: deploy
+          SINGLE_COMMIT: true

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -1,13 +1,8 @@
-name: Documentation and Guides
+name: cFS Documentation and Guides
 
-# Run every time a new commit pushed to main or for pull requests
 on:
   push:
   pull_request:
-
-env:
-  SIMULATION: native
-  REPO_NAME: ${{ github.event.repository.name }}
 
 jobs:
   # Checks for duplicate actions. Skips push actions if there is a matching or
@@ -25,197 +20,56 @@ jobs:
           skip_after_successful_duplicate: 'true'
           do_not_skip: '["push", "workflow_dispatch", "schedule"]'
 
-  build-docs:
-    # Continue if checks-for-duplicates found no duplicates. Always runs for
-    # pull-requests.
+  checkout-and-cache:
+    name: Custom checkout and cache for cFS documents
     needs: checks-for-duplicates
     if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' }}
-    name: cFE Documentation
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
-      - name: Install Dependencies
-        run: sudo apt-get install doxygen graphviz -y
-
-        # Check out the cfs bundle
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           submodules: true
 
-      # Prepare build "recipes"
-      - name: Copy Files
-        run: |
-          cp ./cfe/cmake/Makefile.sample Makefile
-          cp -r ./cfe/cmake/sample_defs sample_defs
-      # Setup the build system
-      - name: Make Prep
-        run: make prep
-
-      - name: Build Docs
-        run: |
-          make doc > make_doc_stdout.txt 2> make_doc_stderr.txt
-          mv build/docs/detaildesign-warnings.log detaildesign-warnings.log
-
-      # Upload documentation logs as artifacts
-      - name: Archive Documentation Build Logs
-        uses: actions/upload-artifact@v2
-        with:
-          name: cFS Docs Artifacts
-          path: |
-            make_doc_stdout.txt
-            make_doc_stderr.txt
-            detaildesign-warnings.log
-
-      - name: Error Check
-        run: |
-          if [[ -s make_doc_stderr.txt ]]; then
-            cat make_doc_stderr.txt
-            exit -1
-          fi
-
-      - name: Warning Check
-        run: |
-          if [[ -s detaildesign-warnings.log ]]; then
-            cat detaildesign-warnings.log
-            exit -1
-          fi
-
-  build:
-    needs: checks-for-duplicates
-    if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' }}
-    name: Build OSAL & Users Guide
-    runs-on: ubuntu-18.04
-
-    steps:
-      # Checks out a copy of your repository on the ubuntu-latest machine
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-          persist-credentials: false
-
-      # Setup the build system
-      - name: Copy Files
-        run: |
-          cp ./cfe/cmake/Makefile.sample Makefile
-          cp -r ./cfe/cmake/sample_defs sample_defs
-          
-      # Setup the build system
-      - name: Make Prep
-        run: make prep
-
-      - name: Install Dependencies
-        run: sudo apt-get install doxygen graphviz -y
-
-      - name: Build OSAL Guide
-        run: |
-          make osalguide > make_osalguide_stdout.txt 2> make_osalguide_stderr.txt
-          mv build/docs/osalguide/osal-apiguide-warnings.log osal-apiguide-warnings.log
-          
-      - name: Archive Osal Guide Build Logs
-        uses: actions/upload-artifact@v2
-        with:
-          name: OSAL Guide Artifacts
-          path: |
-            make_osalguide_stdout.txt
-            make_osalguide_stderr.txt
-            osal-apiguide-warnings.log
-            
-      - name: Check for Errors
-        run: |
-          if [[ -s make_osalguide_stderr.txt ]]; then
-            cat make_osalguide_stderr.txt
-            exit -1
-          fi
-          
-      - name: Check for Warnings
-        run: |
-          if [[ -s osal-apiguide-warnings.log ]]; then
-            cat osal-apiguide-warnings.log
-            exit -1
-          fi
-          
-      - name: Install Dependencies
-        if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
-        run: |
-          sudo apt-get install texlive-latex-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra
-          
-      - name: Generate PDF
-        if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
-        run: |
-          mkdir deploy
-          cd ./build/docs/osalguide/latex
-          make > build.txt
-          mv refman.pdf $GITHUB_WORKSPACE/deploy/OSAL_Users_Guide.pdf
-          # Could add pandoc and convert to github markdown
-          # pandoc CFE_Users_Guide.pdf -t gfm
-          
-      - name: Build Usersguide
-        run: |
-          make usersguide > make_usersguide_stdout.txt 2> make_usersguide_stderr.txt
-          mv build/docs/users_guide/cfe-usersguide-warnings.log cfe-usersguide-warnings.log
-
-      - name: Archive Users Guide Build Logs
-        uses: actions/upload-artifact@v2
-        with:
-          name: Users Guide Artifacts
-          path: |
-            make_usersguide_stdout.txt
-            make_usersguide_stderr.txt
-            cfe-usersguide-warnings.log
-            
-      - name: Error Check
-        run: |
-          if [[ -s make_usersguide_stderr.txt ]]; then
-            cat make_usersguide_stderr.txt
-            exit -1
-          fi
-          
-      - name: Warning Check
-        run: |
-          if [[ -s cfe-usersguide-warnings.log ]]; then
-            cat cfe-usersguide-warnings.log
-            exit -1
-          fi
-          
-      - name: Generate PDF
-        if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
-        run: |
-          set -x
-          cd ./build/docs/users_guide/latex
-          make > build.txt
-          mv refman.pdf $GITHUB_WORKSPACE/deploy/cFE_Users_Guide.pdf
-          # Could add pandoc and convert to github markdown
-          # pandoc CFE_Users_Guide.pdf -t gfm
-          
-      - name: Cache cFS Build Environment for usersguide
-        id: cache-guide
+      - name: Cache Source and Build
+        id: cache-src-bld
         uses: actions/cache@v2
         with:
-          path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/deploy/*
-          key: guide-buildnum-${{ github.run_number }}
-                    
-  deploy:
-    needs: build
-    name: Deploy OSAL & Users Guide
-    runs-on: ubuntu-18.04
+          path: /home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/*
+          key: cfs-doc-${{ github.run_number }}
+
+  build-cfs-documentation:
+    needs: checkout-and-cache
+    name: Build and deploy cFS documents
+    uses: nasa/cFS/.github/workflows/build-deploy-doc.yml@main
+    with:
+      target: "[\"cfe-usersguide\", \"osal-apiguide\", \"mission-doc\"]"
+      cache-key: cfs-doc-${{ github.run_number }}
+      checkout: false
+      deploy: false
+
+  deploy-documentation:
+    needs: build-cfs-documentation
     if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
+    name: Deploy documentation to gh-pages
+    runs-on: ubuntu-latest
 
     steps:
-      - name: Cache cFS Build Environment for osalguide
-        id: cache-guide
-        uses: actions/cache@v2
-        with:
-          path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/deploy/*
-          key: guide-buildnum-${{ github.run_number }}
-          
+      - uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v3
+
+      - name: Display structure of downloaded files
+        run: ls -R
+
+      - name: Move pdfs to deployment directory
+        run: mkdir deploy; mv */*.pdf deploy
+
       - name: Deploy to GitHub
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: deploy
-          CLEAN: false
           SINGLE_COMMIT: true
-          


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #447 
- Fix #455

Note #442 already added enforcement, so this just adds deployment.

**Testing performed**
CI that included nasa/cFE@2085, forced the deployment, and used current branch to get the reusable workflow
Results at https://github.com/skliper/cFS/actions/runs/2161038232

**Expected behavior changes**
Deploys mission doc on push to main

**System(s) tested on**
CI

**Additional context**
Depends on nasa/cFE#2085

**Code contributions**
The cFS repository is provided to bundle the cFS Framework.  It is utilized for bundling submodules, continuous integration testing, and version management and does not contain any software.  Code contributions should be directed to the appropriate submodule.

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC