### PR TITLE
Fix #453, Cleanup shared static analysis workflow

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -32,8 +32,6 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        cppcheck: [non-strict, strict]
 
     steps:      
       - name: Install cppcheck
@@ -45,26 +43,33 @@ jobs:
         with:
           submodules: true
 
-      - name: Run bundle cppcheck
-        run: cppcheck --force --inline-suppr . 2> ${{matrix.cppcheck}}_cppcheck_err.txt
+      - name: Run general cppcheck
+        run: cppcheck --force --inline-suppr . 2> general_cppcheck_err.txt
           
+      - name: Check for general errors
+        run: |
+          if [[ -s general_cppcheck_err.txt ]];
+          then
+            cat general_cppcheck_err.txt
+            exit -1
+          fi
+
         # Run strict static analysis for embedded portions of cfe, osal, and psp
       - name: Strict cppcheck
         if: ${{ inputs.strict-dir-list !='' }}
-        run: cppcheck --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive .${{ inputs.strict-dir-list }} 2> ../${{matrix.cppcheck}}_cppcheck_err.txt
+        run: cppcheck --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ${{ inputs.strict-dir-list }} 2> strict_cppcheck_err.txt
 
-      - name: Archive Static Analysis Artifacts
-        if: ${{ inputs.strict-dir-list !='' || matrix.cppcheck == 'non-strict' }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{matrix.cppcheck}}-cppcheck-err
-          path: ./*cppcheck_err.txt
-
-      - name: Check for errors
-        if: ${{ inputs.strict-dir-list !='' || matrix.cppcheck == 'non-strict' }}
+      - name: Check for strict errors
+        if: ${{ inputs.strict-dir-list !='' }}
         run: |
-          if [[ -s ${{matrix.cppcheck}}_cppcheck_err.txt ]];
+          if [[ -s strict_cppcheck_err.txt ]];
           then
-            cat ${{matrix.cppcheck}}_cppcheck_err.txt
+            cat strict_cppcheck_err.txt
             exit -1
           fi
+
+      - name: Archive Static Analysis Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: cppcheck-errors
+          path: ./*cppcheck_err.txt


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #453 

Removes leading `.` before directory list and removes matrix (slight re-ordering of tests)

**Testing performed**
CI

**Expected behavior changes**
Works on directory lists, just one flow where strict only runs on non-empty `strict-dir-list`

**System(s) tested on**
CI

**Additional context**
Impacts nasa/PSP#333 and nasa/cf#228

**Code contributions**
The cFS repository is provided to bundle the cFS Framework.  It is utilized for bundling submodules, continuous integration testing, and version management and does not contain any software.  Code contributions should be directed to the appropriate submodule.

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC