### PR TITLE
Fix #465 #463, CI document deployment fixes

### DIFF
--- a/.github/workflows/build-deploy-doc.yml
+++ b/.github/workflows/build-deploy-doc.yml
@@ -48,7 +48,7 @@ jobs:
 
   build-doc:
     needs: checks-for-duplicates
-    if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' }}
+    if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' || contains(github.ref, 'main') }}
     name: Build Documentation
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/build-deploy-doc.yml
+++ b/.github/workflows/build-deploy-doc.yml
@@ -58,6 +58,12 @@ jobs:
         target: ${{ fromJson(inputs.target) }}
 
     steps:
+      - name: Reject non-compatible deployment settings
+        if: ${{ inputs.deploy == true && inputs.cache-key != '' }}
+        run: |
+          echo "Deployment when using cache not supported due to password fail issue"
+          exit -1
+
       - name: Get cache if supplied
         id: cache-src-bld
         if: ${{ inputs.cache-key != '' }}

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -23,7 +23,7 @@ jobs:
   checkout-and-cache:
     name: Custom checkout and cache for cFS documents
     needs: checks-for-duplicates
-    if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' }}
+    if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' || contains(github.ref, 'main') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -50,7 +50,7 @@ jobs:
 
   deploy-documentation:
     needs: build-cfs-documentation
-    if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
+    if: ${{ github.event_name == 'push' && contains(github.ref, 'main') }}
     name: Deploy documentation to gh-pages
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #465 
- Fix #463 

Now always running for main branch actions (will deploy on fork if you push main).  Also rejecting attempts to deploy and use the cache at the same time since I can't figure out how to make that work (password fails on deploy).

**Testing performed**
Tested w/ a push of main to my fork at https://github.com/skliper/cFE/actions/runs/2203904971, note that branch also contains updates to deploy locally to avoid the password issue.

**Expected behavior changes**
Deploy on push to main

**System(s) tested on**
CI

**Additional context**
Only caller impact is for cFE that tried to use the cache and reusable deploy.  CF and cFS workflows not impacted.

**Code contributions**
The cFS repository is provided to bundle the cFS Framework.  It is utilized for bundling submodules, continuous integration testing, and version management and does not contain any software.  Code contributions should be directed to the appropriate submodule.

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC