### PR TITLE
Fix #192, Adds check commit message job in format check

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -65,3 +65,31 @@ jobs:
             cat style_differences.txt
             exit -1
           fi
+
+  check-commit-message:
+    name: Check Commit Message
+    needs: check-for-duplicates
+    # Only run for pull-requests.
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-18.04
+    timeout-minutes: 15
+    steps:
+      # Check github pull-request title against the pattern.
+      - name: Check pull-request title
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^((Fix|HotFix|Part)\s\#[0-9]+,\s[a-zA-Z0-9]+|Merge\spull\srequest\s\#[0-9]+\s[a-zA-Z0-9]+|IC:\s[a-zA-Z0-9]+)'
+          error: 'You need at least one "Fix|HotFix|Part #<issue number>, <short description>" line in the pull-request title.'
+          excludeDescription: 'true'
+          excludeTitle: 'false'
+          checkAllCommitMessages: 'false'
+      # Check each commit message associated with the pull-request against the pattern.
+      - name: Check each commit message
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^((Fix|HotFix|Part)\s\#[0-9]+,\s[a-zA-Z0-9]+|Merge\spull\srequest\s\#[0-9]+\s[a-zA-Z0-9]+|IC:\s[a-zA-Z0-9]+)'
+          error: 'You need at least one "Fix|HotFix|Part #<issue number>, <short description>" line in the commit message.'
+          excludeDescription: 'true'
+          excludeTitle: 'true'
+          checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
- Fixes #192 

**Testing performed**
Tested on fork: https://github.com/chillfig/cFS/runs/6427976618?check_suite_focus=true

**Expected behavior changes**
Commit messages not following any of the below conventions will fail the [format-check.yml
](https://github.com/nasa/cFS/blob/main/.github/workflows/format-check.yml)
* `Fix #XYZ, DESCRIPTION` 
* `HotFix #XYZ, DESCRIPTION` 
* `Partial #XYZ, DESCRIPTION` 
* `Merge pull request #XYZ DESCRIPTION` 
* `IC: DESCRIPTION` 


**System(s) tested on**
Ubuntu 18.04

**Additional context**
The regex for `DESCRIPTION` is defined as a string of 1 or more alphanumeric characters.
The regex for `XYZ` is defined as a string of 1 or more numeric characters.

**Code contributions**
The cFS repository is provided to bundle the cFS Framework.  It is utilized for bundling submodules, continuous integration testing, and version management and does not contain any software.  Code contributions should be directed to the appropriate submodule.

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, ASRC Federal
