### PR TITLE
Fix #487, force remove old submodule directory in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -94,7 +94,7 @@ jobs:
           git log -1 --pretty=oneline
           git submodule 
           rm -r .git
-          rm -r ${{ inputs.component-path }} 
+          rm -rf ${{ inputs.component-path }} 
           ln -s ${{github.workspace}} ${{ inputs.component-path }} 
 
       


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [X] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fix #487, Force remove old submodule directory in CodeQL workflow

**Testing performed**
Steps taken to test the contribution:
1. Update codeql-build.yml in another repo to use this workflow
2. Push changes to the repo
3. Verify codeql workflow ran

**Expected behavior changes**
no impact to behavior

**System(s) tested on**
Browser

**Additional context**
Add any other context about the contribution here.

**Code contributions**
The cFS repository is provided to bundle the cFS Framework.  It is utilized for bundling submodules, continuous integration testing, and version management and does not contain any software.  Code contributions should be directed to the appropriate submodule.

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLAs apply to only software contributions.
