### PR TITLE
Fix #509, Rename Tool for CodeQL Results

### DIFF
--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -125,9 +125,21 @@ jobs:
         with:
           add-snippets: true
           category: ${{matrix.scan-type}}
-
+          upload: false
+          output: CodeQL-Sarif-${{ matrix.scan-type }}
+          
+      - name: Rename Sarif
+        run: |
+          mv CodeQL-Sarif-${{ matrix.scan-type }}/cpp.sarif CodeQL-Sarif-${{ matrix.scan-type }}/Codeql-${{ matrix.scan-type }}.sarif
+          sed -i 's/"name" : "CodeQL"/"name" : "CodeQL-${{ matrix.scan-type }}"/g' CodeQL-Sarif-${{ matrix.scan-type }}/Codeql-${{ matrix.scan-type }}.sarif
+          
       - name: Archive Sarif
         uses: actions/upload-artifact@v2
         with:
           name: CodeQL-Sarif-${{ matrix.scan-type }}
-          path: /home/runner/work/${{env.REPO}}/results/cpp.sarif
+          path: CodeQL-Sarif-${{ matrix.scan-type }}
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: CodeQL-Sarif-${{ matrix.scan-type }}/Codeql-${{ matrix.scan-type }}.sarif


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #509 

**Testing performed**
Tested on fork here: https://github.com/ArielSAdams/cFS/actions/runs/2509680609

Tested renaming SARIF file here: https://github.com/ArielSAdams/cFS/actions/runs/2510376525

**Expected behavior changes**
Users can filter between coding standard results and security results for CodeQL by Tool in code scanning alerts. 

The CodeQL sarif file, by default, is named cpp.sarif. The default file is renamed to Codeql-${{ matrix.scan-type }}.sarif so when users download the artifacts from cppcheck and CodeQL, they are not confusing one for the other. 

![image](https://user-images.githubusercontent.com/69638935/174808597-40f155a9-c1eb-40b8-b71e-73482b27c64f.png)

Downside is that the number of alerts are not shown. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal