### PR TITLE
Fix #416, Display cppcheck in Code Scanning Alerts Dashboard

### DIFF
--- a/.github/workflows/static-analysis-misra.yml
+++ b/.github/workflows/static-analysis-misra.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           submodules: true
 
-      - name: get MISRA addon
+      - name: Get MISRA addon
         run: |
             sudo apt-get install git -y
             git clone https://github.com/danmar/cppcheck.git
@@ -52,32 +52,70 @@ jobs:
       - name: Run bundle cppcheck
         if: ${{matrix.cppcheck =='bundle'}}
         run: |
+          cppcheck --addon=misra --force --inline-suppr --quiet . --xml 2> ${{matrix.cppcheck}}_cppcheck_err.xml 
           cppcheck --addon=misra --force --inline-suppr --quiet . 2> ${{matrix.cppcheck}}_cppcheck_err.txt
-          
+
         # Run strict static analysis for embedded portions of cfe, osal, and psp
       - name: cfe strict cppcheck
         if: ${{matrix.cppcheck =='cfe'}}
         run: |
           cd ${{matrix.cppcheck}}
-          cppcheck --addon=misra --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./modules/core_api/fsw ./modules/core_private/fsw ./modules/es/fsw ./modules/evs/fsw ./modules/fs/fsw ./modules/msg/fsw ./modules/resourceid/fsw ./modules/sb/fsw ./modules/sbr/fsw ./modules/tbl/fsw ./modules/time/fsw -UCFE_PLATFORM_TIME_CFG_CLIENT -DCFE_PLATFORM_TIME_CFG_SERVER 2> ../${{matrix.cppcheck}}_cppcheck_err.txt
+          cppcheck --addon=misra --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./modules/core_api/fsw ./modules/core_private/fsw ./modules/es/fsw ./modules/evs/fsw ./modules/fs/fsw ./modules/msg/fsw ./modules/resourceid/fsw ./modules/sb/fsw ./modules/sbr/fsw ./modules/tbl/fsw ./modules/time/fsw -UCFE_PLATFORM_TIME_CFG_CLIENT -DCFE_PLATFORM_TIME_CFG_SERVER --xml 2> ${{matrix.cppcheck}}_cppcheck_err.xml
+          cppcheck --addon=misra --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./modules/core_api/fsw ./modules/core_private/fsw ./modules/es/fsw ./modules/evs/fsw ./modules/fs/fsw ./modules/msg/fsw ./modules/resourceid/fsw ./modules/sb/fsw ./modules/sbr/fsw ./modules/tbl/fsw ./modules/time/fsw -UCFE_PLATFORM_TIME_CFG_CLIENT -DCFE_PLATFORM_TIME_CFG_SERVER 2> ${{matrix.cppcheck}}_cppcheck_err.txt
           
       - name: osal strict cppcheck
         if: ${{matrix.cppcheck =='osal'}}
         run: |
           cd ${{matrix.cppcheck}}
-          cppcheck --addon=misra --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./src/bsp ./src/os 2> ../${{matrix.cppcheck}}_cppcheck_err.txt
+          cppcheck --addon=misra --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./src/bsp ./src/os --xml 2> ${{matrix.cppcheck}}_cppcheck_err.xml
+          cppcheck --addon=misra --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./src/bsp ./src/os 2> ${{matrix.cppcheck}}_cppcheck_err.txt
           
       - name: psp strict cppcheck
         if: ${{matrix.cppcheck =='psp'}}
         run: |
           cd ${{matrix.cppcheck}}
-          cppcheck --addon=misra --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./fsw 2> ../${{matrix.cppcheck}}_cppcheck_err.txt
+          cppcheck --addon=misra --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./fsw --xml 2> ${{matrix.cppcheck}}_cppcheck_err.xml
+          cppcheck --addon=misra --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./fsw 2> ${{matrix.cppcheck}}_cppcheck_err.txt
+
+      - name: Convert bundle cppcheck to sarif 
+        uses: airtower-luna/convert-to-sarif@v0.2.0
+        if: ${{matrix.cppcheck =='bundle'}}
+        with:
+          tool: 'CppCheck'
+          input_file: '${{matrix.cppcheck}}_cppcheck_err.xml'
+          sarif_file: '${{matrix.cppcheck}}_cppcheck_err.sarif'
           
-      - name: Archive Static Analysis Artifacts
-        uses: actions/upload-artifact@v2
+      - name: Convert cfe, osal, psp cppcheck to sarif 
+        uses: airtower-luna/convert-to-sarif@v0.2.0
+        if: ${{matrix.cppcheck !='bundle'}}
+        with:
+          tool: 'CppCheck'
+          input_file: '${{matrix.cppcheck}}/${{matrix.cppcheck}}_cppcheck_err.xml'
+          sarif_file: '${{matrix.cppcheck}}_cppcheck_err.sarif'
+          
+      - name: Define workspace
+        run: |
+          echo "CONTAINER_WORKSPACE=${PWD}" >> ${GITHUB_ENV}
+
+      - name: Archive bundle static analysis artifacts
+        uses: actions/upload-artifact@v3
+        if: ${{matrix.cppcheck =='bundle'}}
         with:
           name: ${{matrix.cppcheck}}-cppcheck-err
-          path: ./*cppcheck_err.txt
+          path: ./*cppcheck_err.*
+
+      - name: Archive osal, cfe, and psp static analysis artifacts
+        uses: actions/upload-artifact@v3
+        if: ${{matrix.cppcheck !='bundle'}}
+        with:
+          name: ${{matrix.cppcheck}}-cppcheck-err
+          path: ./${{matrix.cppcheck}}/*cppcheck_err.*
+          
+      - name: Upload sarif results
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: '${{matrix.cppcheck}}_cppcheck_err.sarif'
+          checkout_path: ${{ env.CONTAINER_WORKSPACE }}
 
       - name: Check for errors
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -43,9 +43,56 @@ jobs:
         with:
           submodules: true
 
-      - name: Run general cppcheck
-        run: cppcheck --force --inline-suppr . 2> general_cppcheck_err.txt
+      - name: Run general cppcheck 
+        run: |
+          cppcheck --force --inline-suppr . --xml 2> general_cppcheck_err.xml  
+          cppcheck --force --inline-suppr . 2> general_cppcheck_err.txt
           
+      - name: Convert general cppcheck
+        uses: airtower-luna/convert-to-sarif@v0.2.0
+        with:
+          tool: 'CppCheck'
+          input_file: 'general_cppcheck_err.xml'
+          sarif_file: 'general_cppcheck_err.sarif'
+          
+      - name: Define workspace
+        run: |
+          echo "CONTAINER_WORKSPACE=${PWD}" >> ${GITHUB_ENV}
+          
+      - name: Upload general SARIF results
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'general_cppcheck_err.sarif'
+          checkout_path: ${{ env.CONTAINER_WORKSPACE }}
+          
+        # Run strict static analysis for embedded portions of cfe, osal, and psp
+      - name: Strict cppcheck
+        if: ${{ inputs.strict-dir-list !='' }}
+        run: |
+          cppcheck --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ${{ inputs.strict-dir-list }} --xml 2> strict_cppcheck_err.xml 
+          cppcheck --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ${{ inputs.strict-dir-list }} 2> strict_cppcheck_err.txt
+ 
+      - name: Convert strict cppcheck
+        uses: airtower-luna/convert-to-sarif@v0.2.0
+        if: ${{ inputs.strict-dir-list !='' }}
+        with:
+          tool: 'CppCheck'
+          input_file: 'strict_cppcheck_err.xml'
+          sarif_file: 'strict_cppcheck_err.sarif'
+
+      - name: Archive static analysis artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: cppcheck-errors
+          path: ./*cppcheck_err.*
+
+      - name: Upload strict SARIF results
+        uses: github/codeql-action/upload-sarif@v2
+        if: ${{ inputs.strict-dir-list !='' }}
+        with:
+          sarif_file: 'strict_cppcheck_err.sarif'
+          checkout_path: ${{ env.CONTAINER_WORKSPACE }}
+  
       - name: Check for general errors
         run: |
           if [[ -s general_cppcheck_err.txt ]];
@@ -53,12 +100,6 @@ jobs:
             cat general_cppcheck_err.txt
             exit -1
           fi
-
-        # Run strict static analysis for embedded portions of cfe, osal, and psp
-      - name: Strict cppcheck
-        if: ${{ inputs.strict-dir-list !='' }}
-        run: cppcheck --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ${{ inputs.strict-dir-list }} 2> strict_cppcheck_err.txt
-
       - name: Check for strict errors
         if: ${{ inputs.strict-dir-list !='' }}
         run: |
@@ -67,9 +108,3 @@ jobs:
             cat strict_cppcheck_err.txt
             exit -1
           fi
-
-      - name: Archive Static Analysis Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: cppcheck-errors
-          path: ./*cppcheck_err.txt


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #416 

**Testing performed**
Tested on fork - Static analysis: https://github.com/ArielSAdams/cFS/runs/6990609543?check_suite_focus=true
Tested on fork - Static analysis misra: https://github.com/ArielSAdams/cFS/runs/6990964130?check_suite_focus=true

**Expected behavior changes**
Users can view results from cppcheck in the code scanning alerts. 

Removed cat command that displays errors. Output of cppcheck file is now .xml instead of .txt to be able to convert to .sarif. 

Example of cppcheck in code scanning alerts:
![image](https://user-images.githubusercontent.com/69638935/174874772-8d081830-515d-475e-a2e2-3e28ee9d2104.png)

**Additional context**
Number of alerts are not provided. Created a forum to investigate this: https://github.community/t/cannot-view-number-of-code-scanning-alerts/257644. Not sure if this is due to the repository being a forked repo. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal
