### PR TITLE
Fix #537, commit and format check doesn't execute when PR title format fails

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -91,6 +91,7 @@ jobs:
       # Check each commit message associated with the pull-request against the pattern.
       - name: Check each commit message
         uses: gsactions/commit-message-checker@v1
+        if: always()
         with:
           pattern: '^((Fix|HotFix|Part)\s\#[0-9]+,\s[a-zA-Z0-9]+|Merge\spull\srequest\s\#[0-9]+\s[a-zA-Z0-9]+|IC:\s[a-zA-Z0-9]+)'
           error: 'You need at least one "Fix|HotFix|Part #<issue number>, <short description>" line in the commit message.'


### PR DESCRIPTION
Fixes nasa/cFS#537 with continue-on-error solution.

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
- Fixes nasa/cFS#537

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - The action continues even if title format check failes

**Code contributions**
The cFS repository is provided to bundle the cFS Framework.  It is utilized for bundling submodules, continuous integration testing, and version management and does not contain any software.  Code contributions should be directed to the appropriate submodule.

**Contributor Info - All information REQUIRED for consideration of pull request**
Personal
