### PR TITLE
Fix #520, remove cmake_minimum_required in tools

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,4 @@
 # CMake snippet for building the host-side tools.
-cmake_minimum_required(VERSION 2.6.4)
 project(CFETOOLS C)
 
 add_subdirectory(cFS-GroundSystem/Subsystems/cmdUtil)


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
The tools CMakeLists.txt file just adds the subdirectories, it has no logic.
The old version being referenced here triggers a deprecation warning, so just remove it.

Fixes #520

**Testing performed**
Build using cmake 3.20

**Expected behavior changes**
No deprecation warning

**System(s) tested on**
RHEL 8

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.