### PR TITLE
Fix #530, Default CI to bash to apply pipefail

### DIFF
--- a/.github/workflows/build-cfs-deprecated.yml
+++ b/.github/workflows/build-cfs-deprecated.yml
@@ -12,6 +12,11 @@ env:
   CTEST_OUTPUT_ON_FAILURE: true
   REPO_NAME: ${{ github.event.repository.name }}
 
+# Force bash to apply pipefail option so pipeline failures aren't masked
+defaults:
+  run:
+    shell: bash
+
 jobs:
   #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
   check-for-duplicates:

--- a/.github/workflows/build-cfs-rtems4.11.yml
+++ b/.github/workflows/build-cfs-rtems4.11.yml
@@ -9,6 +9,10 @@ env:
   OMIT_DEPRECATED: true
   CTEST_OUTPUT_ON_FAILURE: true
 
+# Force bash to apply pipefail option so pipeline failures aren't masked
+defaults:
+  run:
+    shell: bash
 
 jobs:
   #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 

--- a/.github/workflows/build-cfs-rtems5.yml
+++ b/.github/workflows/build-cfs-rtems5.yml
@@ -9,6 +9,10 @@ env:
   OMIT_DEPRECATED: true
   CTEST_OUTPUT_ON_FAILURE: true
 
+# Force bash to apply pipefail option so pipeline failures aren't masked
+defaults:
+  run:
+    shell: bash
 
 jobs:
   #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 

--- a/.github/workflows/build-cfs.yml
+++ b/.github/workflows/build-cfs.yml
@@ -12,6 +12,11 @@ env:
   CTEST_OUTPUT_ON_FAILURE: true
   REPO_NAME: ${{ github.event.repository.name }}
 
+# Force bash to apply pipefail option so pipeline failures aren't masked
+defaults:
+  run:
+    shell: bash
+
 jobs:
   #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
   check-for-duplicates:

--- a/.github/workflows/build-deploy-doc.yml
+++ b/.github/workflows/build-deploy-doc.yml
@@ -30,6 +30,11 @@ on:
         required: false
         default: true
 
+# Force bash to apply pipefail option so pipeline failures aren't masked
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # Checks for duplicate actions. Skips push actions if there is a matching or
   # duplicate pull-request action.

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -4,6 +4,11 @@ on:
   push:
   pull_request:
 
+# Force bash to apply pipefail option so pipeline failures aren't masked
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # Checks for duplicate actions. Skips push actions if there is a matching or
   # duplicate pull-request action.

--- a/.github/workflows/build-run-app.yml
+++ b/.github/workflows/build-run-app.yml
@@ -15,6 +15,11 @@ on:
         required: false
         default: ''
 
+# Force bash to apply pipefail option so pipeline failures aren't masked
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # Checks for duplicate actions. Skips push actions if there is a matching or
   # duplicate pull-request action.

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,6 +4,11 @@ name: Changelog
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+# Force bash to apply pipefail option so pipeline failures aren't masked
+defaults:
+  run:
+    shell: bash
     
 jobs:
   build:

--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -40,6 +40,11 @@ on:
         default: false 
         required: false
 
+# Force bash to apply pipefail option so pipeline failures aren't masked
+defaults:
+  run:
+    shell: bash
+
 env:
   SIMULATION: native
   ENABLE_UNIT_TESTS: ${{inputs.test}}

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -5,6 +5,11 @@ on:
   push:
   pull_request:
   workflow_call:
+
+# Force bash to apply pipefail option so pipeline failures aren't masked
+defaults:
+  run:
+    shell: bash
   
 jobs:
   #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 

--- a/.github/workflows/static-analysis-misra.yml
+++ b/.github/workflows/static-analysis-misra.yml
@@ -4,6 +4,11 @@ name: Static Analysis with MISRA
 on:
   workflow_dispatch:
 
+# Force bash to apply pipefail option so pipeline failures aren't masked
+defaults:
+  run:
+    shell: bash
+
 jobs:
   #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action.
   check-for-duplicates:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -8,6 +8,11 @@ on:
         type: string
         default: ''
 
+# Force bash to apply pipefail option so pipeline failures aren't masked
+defaults:
+  run:
+    shell: bash
+
 jobs:
   #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
   check-for-duplicates:

--- a/.github/workflows/unit-test-coverage.yml
+++ b/.github/workflows/unit-test-coverage.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: 0
 
+# Force bash to apply pipefail option so pipeline failures aren't masked
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # Checks for duplicate actions. Skips push actions if there is a matching or
   # duplicate pull-request action.


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #530

Without the bash pipefail option return codes can get masked
missing failures.  Specifically seen in the unit test reusable
workflow where ctest returns were masked.  By forcing
the default shell as bash, GitHub applies the pipefail option.

**Testing performed**
CI

Also tested from cf with https://github.com/skliper/CF/runs/7543285379?check_suite_focus=true (pointing to this branch) to confirm the failed ctest causes the CI to fail.

**Expected behavior changes**
Any failure in a pipeline will fail the CI step

**System(s) tested on**
CI

**Additional context**
Originally seen in CF

**Code contributions**
The cFS repository is provided to bundle the cFS Framework.  It is utilized for bundling submodules, continuous integration testing, and version management and does not contain any software.  Code contributions should be directed to the appropriate submodule.

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC