### PR TITLE
Fix #511, adds lcov to archived results

### DIFF
--- a/.github/workflows/unit-test-coverage.yml
+++ b/.github/workflows/unit-test-coverage.yml
@@ -122,3 +122,4 @@ jobs:
           path: |
             test_results.txt
             lcov_out.txt
+            lcov


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #511

**Testing performed**
Tested on forked nasa/CS commit using the github workflow changes from this pull request: https://github.com/chillfig/CS/actions/runs/2870659607

**Expected behavior changes**
The code coverage report (index.html) is accessible from the github workflow call.

**System(s) tested on**
 - Ubuntu 18.04

**Additional context**
None

**Code contributions**
The cFS repository is provided to bundle the cFS Framework.  It is utilized for bundling submodules, continuous integration testing, and version management and does not contain any software.  Code contributions should be directed to the appropriate submodule.

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, ASRC Federal
