### PR TITLE
Fix #560, Remove Rules in CodeQL Coding Standard

### DIFF
--- a/.github/codeql/jpl-misra.qls
+++ b/.github/codeql/jpl-misra.qls
@@ -4,18 +4,27 @@
 # Restrict to only the queries with the following ID patterns.
 - include:
     id:
-      # Regular expression matching all query IDs that start with `cpp/jpl-c/`
-      # This covers all queries in the `JPL_C` directory,
-      # but matching on query ID is more stable.
-      - /cpp/jpl-c/*/
-      # Specific JSF queries, identified by query ID.
-      # MISRA Rule 9-5-1
-      - cpp/jsf/av-rule-153
+      # MISRA Rule 5-3-2
+      - cpp/jsf/av-rule-173
+      # MISRA Rule 5-14-1
+      - cpp/jsf/av-rule-165
       # MISRA Rule 5-18-1
       - cpp/jsf/av-rule-168
       # MISRA 6-2-2
       - cpp/jsf/av-rule-202
-      # MISRA Rule 5-14-1
-      - cpp/jsf/av-rule-165
-      # MISRA Rule 5-3-2
-      - cpp/jsf/av-rule-173
+      # MISRA Rule 9-5-1
+      - cpp/jsf/av-rule-153
+      # JPL Rules
+      - /cpp/jpl-c/*/
+# Exclude queries with too many results
+- exclude: 
+    id: 
+      # JPL 14
+      - cpp/jpl-c/checking-return-values
+      # JPL 15
+      - cpp/jpl-c/checking-parameter-values
+      # JPL 17
+      - cpp/jpl-c/basic-int-types
+      # JPL 24
+      - cpp/jpl-c/multiple-stmts-per-line
+      - cpp/jpl-c/multiple-var-decls-per-line


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #560. Removes JPL rules 14, 15, 17, and 24. 

**Testing performed**
Tested on fork

**Expected behavior changes**
CodeQL workflow should no longer fail. Results for the coding standard job will be uploaded. 

**Additional context**
On the forked repo, when testing, there were 4484 results for cFS. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, MCSG Technologies
