### PR TITLE
Fix #575, Resolve CodeQL Paths Ignore Issues

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,16 +2,7 @@ name: "CodeQL Analysis: cFS-Bundle"
 
 on:
   push:
-    paths-ignore: 
-    - '**/*.md'
-    - '**/*.txt'
-    - '**/*.dox'
-
   pull_request:
-    paths-ignore: 
-    - '**/*.md'
-    - '**/*.txt'
-    - '**/*.dox'
 
 jobs:
   codeql:

--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -138,6 +138,16 @@ jobs:
           mv CodeQL-Sarif-${{ matrix.scan-type }}/cpp.sarif CodeQL-Sarif-${{ matrix.scan-type }}/Codeql-${{ matrix.scan-type }}.sarif
           sed -i 's/"name" : "CodeQL"/"name" : "CodeQL-${{ matrix.scan-type }}"/g' CodeQL-Sarif-${{ matrix.scan-type }}/Codeql-${{ matrix.scan-type }}.sarif
           
+      - name: filter-sarif
+        uses: zbazztian/filter-sarif@master
+        with:
+            patterns: |
+                -**/*.md
+                -**/*.txt
+                -**/*.dox
+            input: CodeQL-Sarif-${{ matrix.scan-type }}/Codeql-${{ matrix.scan-type }}.sarif
+            output: CodeQL-Sarif-${{ matrix.scan-type }}/Codeql-${{ matrix.scan-type }}.sarif
+            
       - name: Archive Sarif
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #575 

**Testing performed**
Tested on ArielSAdams/cFS fork on the test-paths-ignore branch. As seen in the picture, there is no issues thrown for paths ignore.
![image](https://user-images.githubusercontent.com/69638935/190415147-b1e86992-a84d-4acd-a922-e658d3efe184.png)

**Expected behavior changes**
No behavior change.

**Additional context**
Allows cFS and its submodules to be consistent and all ignore documentation files. Currently, only a few repos ignore these files. Repos like cFE needs to remove paths ignore from the CodeQL workflow if approved.

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, MCSG Tech
