### PR TITLE
Fix #583, Fetch Documentation Archives

### DIFF
--- a/.github/workflows/build-deploy-doc.yml
+++ b/.github/workflows/build-deploy-doc.yml
@@ -103,7 +103,7 @@ jobs:
         run: make prep
 
       - name: Install Doxygen Dependencies
-        run: sudo apt-get install doxygen graphviz -y
+        run: sudo apt-get update && sudo apt-get install doxygen graphviz -y
 
       - name: Install PDF Generation Dependencies
         if: ${{ inputs.buildpdf == true }}


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #583 

**Testing performed**
Tested on fork

![image](https://user-images.githubusercontent.com/69638935/194995940-be61ab53-f353-4393-9554-2d9641509b31.png)

Tested locally in Docker.

**Additional context**
The issue is thrown at random times. Thrown here: https://github.com/nasa/cFS/actions/runs/3185348707/jobs/5194900560 but not here: https://github.com/nasa/cFS/actions/runs/3185232492/jobs/5194803479. 

**Expected behavior changes**
Fixes failing cFS Documentation and Guides workflow. It had an issue installing PDF generation dependencies. Same behavior.

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, MCSG Tech
