### PR TITLE
Fix #593, Add Category to Cppcheck Workflow

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           sarif_file: 'general_cppcheck_err.sarif'
           checkout_path: ${{ env.CONTAINER_WORKSPACE }}
+          category: 'General-cppcheck'
           
         # Run strict static analysis for embedded portions of cfe, osal, and psp
       - name: Strict cppcheck
@@ -97,6 +98,7 @@ jobs:
         with:
           sarif_file: 'strict_cppcheck_err.sarif'
           checkout_path: ${{ env.CONTAINER_WORKSPACE }}
+          category: 'Strict-cppcheck'
   
       - name: Check for general errors
         run: |


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #593 

**Testing performed**
Made changes to cFS fork and test on PSP fork. 

![image](https://user-images.githubusercontent.com/69638935/195883362-cbb07b9f-ab3b-4c2d-8152-70c4dbc12281.png)

**Expected behavior changes**
Same behavior. Added category so second SARIF file upload does not fail. 

**Additional context**
Workflow may fail due to ubuntu being out of date. GitHub will now throw brownouts for out of date ubuntu versions. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, MCSG Tech
