### PR TITLE
Fix #566, Adds CCB Agenda generation workflow

### DIFF
--- a/.github/scripts/create_ccb_agenda.py
+++ b/.github/scripts/create_ccb_agenda.py
@@ -1,0 +1,69 @@
+import subprocess
+import json
+import sys
+import time
+import os
+
+# extract pull request data from GitHub
+repos = ['cFS', 'cFE', 'osal', 'psp', 'sch_lab', 'ci_lab', 'to_lab', 'sample_app', 'sample_lib', 'elf2cfetbl', 'tblcrctool','cFS-GroundSystem', 'CF', 'CS', 'DS','FM', 'HK', 'HS', 'LC', 'MD', 'MM', 'SC']
+
+for repo in repos:
+    subprocess.Popen('gh pr list --repo nasa/' + str(repo) + ' --search "draft:false" --json number,author,title,url,additions,deletions,labels | jq -c ' + '\'reduce range(0, length) as $index (.; (.[$index].author=.[$index].author.login | .[$index].number=(.[$index].number|"\'' + str(repo) + '\' PR #\(.)") )) | .[]\' ' + '>> temp.json', shell=True)
+
+time.sleep(5)
+subprocess.Popen('jq -s . temp.json > prs.json', shell=True)
+time.sleep(5)
+
+# load a list of pull requests as python dictionaries
+with open ('prs.json') as prs_file:
+    prs = json.load(prs_file)
+
+PrData          = dict()    # {author: [pr1, pr2, pr3, ...]}
+AuthorPrChanges = dict()    # {author: #TotalChanges}
+
+for pr in prs:
+    ignore = False
+    for label in pr['labels']:
+        if label['name'] == 'CCB:Ignore' or label['name'] == 'CCB:Approved':
+            ignore = True
+            break
+    if ignore == False:
+        if pr['author'] not in PrData:
+            PrData[pr['author']] = [pr]
+            AuthorPrChanges[pr['author']] = pr['additions'] + pr['deletions']
+        else:
+            PrData[pr['author']].append(pr)
+            AuthorPrChanges[pr['author']] += pr['additions'] + pr['deletions']
+
+# no prs to write, exit program
+if len(PrData) == 0:
+    print("Failed to find relevant Pull Requests for the agenda. Exiting...\n")
+    sys.exit()
+
+# re-order dict according to sum(additions, deletions) of each pr for each author
+AuthorPrChanges = {k: v for k, v in sorted(AuthorPrChanges.items(), key=lambda item: item[1])}
+
+# write to markdown
+CCBfilename = "CCBAgenda.md"
+with open(CCBfilename, 'w') as f:
+    f.write("## Items for Discussion\n\n")
+    for author in AuthorPrChanges.keys():
+        f.write("### @" + author + "\n\n")
+        for pr_auth in PrData[author]:
+            if (author == pr_auth['author']):
+                f.write("[" + pr_auth['number'] + "](" + pr_auth['url'].replace("pull", "issues") + ") " + pr_auth['title'] + "\n\n")
+
+# close files
+f.close()
+prs_file.close()
+time.sleep(5)
+try:
+    os.remove("prs.json")
+    os.remove("temp.json")
+except OSError:
+    pass
+
+time.sleep(5)
+
+if (os.stat(CCBfilename).st_size != 0):
+    print("CCB markdown has been successfully created")

--- a/.github/workflows/cfs-wiki.yml
+++ b/.github/workflows/cfs-wiki.yml
@@ -1,0 +1,32 @@
+name: Update wiki
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Force bash to apply pipefail option so pipeline failures aren't masked
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      
+      - name: create CCB agenda
+        run: python3 .github/scripts/create_ccb_agenda.py
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Archive CCB agenda artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ccb-agenda
+          path: ./CCBAgenda.md


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #566 

**Testing performed**
Test on fork: https://github.com/chillfig/cFS/actions/runs/3338091197
1) Navigate to "update wiki" action (https://github.com/chillfig/cFS/actions/workflows/cfs-wiki.yml)
2) Click "Run workflow" drop-down on right-hand side of screen
3) For "Use workflow from", select "ccbAgenda" branch.
4) Click green button "Run workflow"
5.) Navigate to "update wiki" action and observe newly created "ccb-agenda" artifact.

**Expected behavior changes**
User can use this workflow to update the nasa/cFS wiki page with a new CCB agenda markdown file, and other updates to the wiki page's _Sidebar.md and Home.md files. The workflow can be ran any day of the week and appropriately handle correct date stamping. The CCB agenda markdown file generated with this workflow is ordered from top to bottom of authors with pull requests totaling least additions/deletions to most. A user manually runs this workflow from the Actions tab of nasa/cFS.

**System(s) tested on**
Forked cFS wiki: https://github.com/chillfig/cFS/wiki

**Additional context**
N/A

**Code contributions**
The cFS repository is provided to bundle the cFS Framework.  It is utilized for bundling submodules, continuous integration testing, and version management and does not contain any software.  Code contributions should be directed to the appropriate submodule.

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems
