### PR TITLE
Fix #621, update action versions to v3

### DIFF
--- a/.github/workflows/build-cfs-deprecated.yml
+++ b/.github/workflows/build-cfs-deprecated.yml
@@ -18,7 +18,7 @@ defaults:
     shell: bash
 
 jobs:
-  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action.
   check-for-duplicates:
     runs-on: ubuntu-latest
     # Map a step output to a job output
@@ -31,7 +31,7 @@ jobs:
           concurrent_skipping: 'same_content'
           skip_after_successful_duplicate: 'true'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
-                  
+
   build-cfs-omit-deprecated-false:
     name: "[Deprecated] Build"
     needs: check-for-duplicates
@@ -45,36 +45,36 @@ jobs:
 
     # Set the type of machine to run on
     env:
-      BUILDTYPE: ${{ matrix.buildtype }}    
+      BUILDTYPE: ${{ matrix.buildtype }}
 
     steps:
       - name: Cache Source and Build
         id: cache-src-bld
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/*
           key: deprecated-build-${{ github.run_number }}-${{ matrix.buildtype }}
-          
+
       - name: Checkout cFS
         if: steps.cache-src-bld.outputs.cache-hit != 'true'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
-          
+
       - name: Check versions
         run: git submodule
-        
+
       - name: Copy Makefile
         run: |
           cp ./cfe/cmake/Makefile.sample Makefile
           cp -r ./cfe/cmake/sample_defs sample_defs
 
       - name: Prep Build
-        run: make prep 
-          
+        run: make prep
+
       - name: Make
         run: make install
-        
+
   tests-and-coverage-omit-deprecated-false:
     name: "[Deprecated] Run Unit Tests and Check Coverage"
     needs: build-cfs-omit-deprecated-false
@@ -93,14 +93,14 @@ jobs:
     steps:
       - name: Install Dependencies
         run: sudo apt-get install lcov -y
-        
+
       - name: Cache Source and Deprecated Build
         id: cache-src-bld
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/*
-          key: deprecated-build-${{ github.run_number }}-${{ matrix.buildtype }}          
-      
+          key: deprecated-build-${{ github.run_number }}-${{ matrix.buildtype }}
+
       - name: Run Tests
         run: make test
 
@@ -124,7 +124,7 @@ jobs:
     steps:
       - name: Cache Source and Deprecated Build
         id: cache-src-bld
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/*
           key: deprecated-build-${{ github.run_number }}-${{ matrix.buildtype }}
@@ -141,7 +141,7 @@ jobs:
         working-directory: ./build/exe/cpu1/
 
       - name: Archive cFS Startup Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cFS-startup-log-omit-deprecate-false${{ matrix.buildtype }}
           path: ./build/exe/cpu1/cFS_startup_cpu1.txt
@@ -162,16 +162,16 @@ jobs:
     name: "[DEPRECATED] cFS Functional Tests"
     runs-on: ubuntu-20.04
     timeout-minutes: 15
-    
+
     strategy:
       fail-fast: false
       matrix:
         buildtype: [debug, release]
 
-    steps:      
+    steps:
       - name: Cache Source and Deprecated Build
         id: cache-src-bld
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/*
           key: deprecated-build-${{ github.run_number }}-${{ matrix.buildtype }}
@@ -188,34 +188,34 @@ jobs:
           ../host/cmdUtil --pktid=0x1806 --cmdcode=14 --endian=LE --uint32=2
           ../host/cmdUtil --pktid=0x1806 --cmdcode=4 --endian=LE --string="20:CFE_TEST_APP" --string="20:CFE_TestMain" --string="64:cfe_testcase" --uint32=16384 --uint8=0 --uint8=0 --uint16=100
           sleep 30
-          counter=0 
-          while [[ ! -f cf/cfe_test.log ]]; do 
-            temp=$(grep -c "BEGIN" cf/cfe_test.tmp) 
-              
+          counter=0
+          while [[ ! -f cf/cfe_test.log ]]; do
+            temp=$(grep -c "BEGIN" cf/cfe_test.tmp)
+
             if [ $temp -eq $counter ]; then
               echo "Test is frozen. Quiting"
               break
             fi
-            counter=$(grep -c "BEGIN" cf/cfe_test.tmp)            
+            counter=$(grep -c "BEGIN" cf/cfe_test.tmp)
             echo "Waiting for CFE Tests"
             sleep 60
           done
-          
+
           ../host/cmdUtil --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
         working-directory: ./build/exe/cpu1/
 
       - name: Archive Functional Test Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cFS-functional-test-log-omit-deprecate-false-${{ matrix.buildtype }}
           path: ./build/exe/cpu1/cf/cfe_test.log
 
       - name: Check for cFS Warnings
-        run: |  
+        run: |
           if [[ -z $(grep -i "SUMMARY.*FAIL::0.*TSF::0.*TTF::0" cf/cfe_test.log) ]]; then
                   echo "Must resolve Test Failures in cFS Test App before submitting a pull request"
                   echo ""
                   grep -i '\[ FAIL]\|\[  TSF]\|\[  TTF]' cf/cfe_test.log
                   exit -1
           fi
-        working-directory: ./build/exe/cpu1/  
+        working-directory: ./build/exe/cpu1/

--- a/.github/workflows/build-cfs-rtems4.11.yml
+++ b/.github/workflows/build-cfs-rtems4.11.yml
@@ -15,7 +15,7 @@ defaults:
     shell: bash
 
 jobs:
-  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action.
   check-for-duplicates:
     runs-on: ubuntu-latest
     # Map a step output to a job output
@@ -28,7 +28,7 @@ jobs:
           concurrent_skipping: 'same_content'
           skip_after_successful_duplicate: 'true'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
-          
+
   build-cfs:
     #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
     needs: check-for-duplicates
@@ -51,7 +51,7 @@ jobs:
     steps:
       # Check out the cfs bundle
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -92,7 +92,7 @@ jobs:
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -104,7 +104,7 @@ jobs:
 
       # Setup the build system
       - name: Make
-        run: | 
+        run: |
           make SIMULATION=i686-rtems4.11 prep
           make install
 
@@ -124,7 +124,7 @@ jobs:
 
       # Always archive test logs
       - name: Archive cFS Test Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         # Runs even if previous steps have failed
         if: always()
         with:

--- a/.github/workflows/build-cfs-rtems5.yml
+++ b/.github/workflows/build-cfs-rtems5.yml
@@ -15,7 +15,7 @@ defaults:
     shell: bash
 
 jobs:
-  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action.
   check-for-duplicates:
     runs-on: ubuntu-latest
     # Map a step output to a job output
@@ -28,7 +28,7 @@ jobs:
           concurrent_skipping: 'same_content'
           skip_after_successful_duplicate: 'true'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
-          
+
   build-cfs:
     #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
     needs: check-for-duplicates
@@ -51,7 +51,7 @@ jobs:
     steps:
       # Check out the cfs bundle
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -92,7 +92,7 @@ jobs:
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -122,7 +122,7 @@ jobs:
 
       # Always archive test logs
       - name: Archive cFS Test Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         # Runs even if previous steps have failed
         if: always()
         with:

--- a/.github/workflows/build-cfs.yml
+++ b/.github/workflows/build-cfs.yml
@@ -18,7 +18,7 @@ defaults:
     shell: bash
 
 jobs:
-  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action.
   check-for-duplicates:
     runs-on: ubuntu-latest
     # Map a step output to a job output
@@ -31,9 +31,9 @@ jobs:
           concurrent_skipping: 'same_content'
           skip_after_successful_duplicate: 'true'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
-                  
+
   build-cfs-omit-deprecated-true:
-    name: Build    
+    name: Build
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
     runs-on: ubuntu-20.04
@@ -45,35 +45,35 @@ jobs:
 
     # Set the type of machine to run on
     env:
-      BUILDTYPE: ${{ matrix.buildtype }}    
+      BUILDTYPE: ${{ matrix.buildtype }}
 
     steps:
       - name: Cache Source and Build
         id: cache-src-bld
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/*
           key: build-${{ github.run_number }}-${{ matrix.buildtype }}
-          
+
       - name: Checkout cFS
         if: steps.cache-src-bld.outputs.cache-hit != 'true'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
-          
+
       - name: Check versions
         run: git submodule
-        
+
       - name: Copy Makefile
         run: |
           cp ./cfe/cmake/Makefile.sample Makefile
           cp -r ./cfe/cmake/sample_defs sample_defs
       - name: Prep Build
-        run: make prep 
-          
+        run: make prep
+
       - name: Make
         run: make install
-        
+
   tests-and-coverage-omit-deprecated-true:
     name: Run Unit Tests and Check Coverage
     needs: build-cfs-omit-deprecated-true
@@ -92,14 +92,14 @@ jobs:
     steps:
       - name: Install Dependencies
         run: sudo apt-get install lcov -y
-        
+
       - name: Cache Source and Build
         id: cache-src-bld
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/*
-          key: build-${{ github.run_number }}-${{ matrix.buildtype }}          
-      
+          key: build-${{ github.run_number }}-${{ matrix.buildtype }}
+
       - name: Run Tests
         run: make test
 
@@ -123,7 +123,7 @@ jobs:
     steps:
       - name: Cache Source and Build
         id: cache-src-bld
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/*
           key: build-${{ github.run_number }}-${{ matrix.buildtype }}
@@ -140,7 +140,7 @@ jobs:
         working-directory: ./build/exe/cpu1/
 
       - name: Archive cFS Startup Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cFS-startup-log-omit-deprecate-true-${{ matrix.buildtype }}
           path: ./build/exe/cpu1/cFS_startup_cpu1.txt
@@ -160,16 +160,16 @@ jobs:
     needs: run-cfs-omit-deprecated-true
     runs-on: ubuntu-20.04
     timeout-minutes: 15
-    
+
     strategy:
       fail-fast: false
       matrix:
         buildtype: [debug, release]
 
-    steps:      
+    steps:
       - name: Cache Source and Build
         id: cache-src-bld
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/*
           key: build-${{ github.run_number }}-${{ matrix.buildtype }}
@@ -186,34 +186,34 @@ jobs:
           ../host/cmdUtil --pktid=0x1806 --cmdcode=14 --endian=LE --uint32=2
           ../host/cmdUtil --pktid=0x1806 --cmdcode=4 --endian=LE --string="20:CFE_TEST_APP" --string="20:CFE_TestMain" --string="64:cfe_testcase" --uint32=16384 --uint8=0 --uint8=0 --uint16=100
           sleep 30
-          counter=0 
-          while [[ ! -f cf/cfe_test.log ]]; do 
-            temp=$(grep -c "BEGIN" cf/cfe_test.tmp) 
-              
+          counter=0
+          while [[ ! -f cf/cfe_test.log ]]; do
+            temp=$(grep -c "BEGIN" cf/cfe_test.tmp)
+
             if [ $temp -eq $counter ]; then
               echo "Test is frozen. Quiting"
               break
             fi
-            counter=$(grep -c "BEGIN" cf/cfe_test.tmp)            
+            counter=$(grep -c "BEGIN" cf/cfe_test.tmp)
             echo "Waiting for CFE Tests"
             sleep 60
           done
-          
+
           ../host/cmdUtil --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
         working-directory: ./build/exe/cpu1/
 
       - name: Archive cFS Startup Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cFS-functional-test-log-omit-deprecate-true-${{ matrix.buildtype }}
           path: ./build/exe/cpu1/cf/cfe_test.log
 
       - name: Check for cFS Warnings
-        run: |  
+        run: |
           if [[ -z $(grep -i "SUMMARY.*FAIL::0.*TSF::0.*TTF::0" cf/cfe_test.log) ]]; then
                   echo "Must resolve Test Failures in cFS Test App before submitting a pull request"
                   echo ""
                   grep -i '\[ FAIL]\|\[  TSF]\|\[  TTF]' cf/cfe_test.log
                   exit -1
           fi
-        working-directory: ./build/exe/cpu1/  
+        working-directory: ./build/exe/cpu1/

--- a/.github/workflows/build-deploy-doc.yml
+++ b/.github/workflows/build-deploy-doc.yml
@@ -72,21 +72,21 @@ jobs:
       - name: Get cache if supplied
         id: cache-src-bld
         if: ${{ inputs.cache-key != '' }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/*
           key: ${{ inputs.cache-key }}
 
       - name: Checkout Bundle Main
         if: ${{ inputs.app-name != '' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
           repository: nasa/cFS
 
       - name: Checkout Repo
         if: ${{ inputs.app-name != '' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: apps/${{ inputs.app-name }}
 
@@ -116,28 +116,28 @@ jobs:
           mv build/docs/${{ matrix.target }}/${{ matrix.target }}-warnings.log .
 
       - name: Archive Document Build Logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.target }}_doc_build_logs
           path: |
             ${{ matrix.target }}_stdout.txt
             ${{ matrix.target }}_stderr.txt
             ${{ matrix.target }}-warnings.log
-            
+
       - name: Check For Document Build Errors
         run: |
           if [[ -s ${{ matrix.target }}_stderr.txt ]]; then
             cat ${{ matrix.target }}_stderr.txt
             exit -1
           fi
-          
+
       - name: Check For Document Warnings
         run: |
           if [[ -s ${{ matrix.target }}-warnings.log ]]; then
             cat ${{ matrix.target }}-warnings.log
             exit -1
           fi
-          
+
       - name: Generate PDF
         if: ${{ inputs.buildpdf == true }}
         run: |
@@ -149,7 +149,7 @@ jobs:
 
       - name: Archive PDF
         if: ${{ inputs.buildpdf == true }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.target }}_pdf
           path: ./deploy/${{ matrix.target }}.pdf

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -33,13 +33,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
       - name: Cache Source and Build
         id: cache-src-bld
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/*
           key: cfs-doc-${{ github.run_number }}
@@ -50,7 +50,7 @@ jobs:
     uses: nasa/cFS/.github/workflows/build-deploy-doc.yml@main
     with:
       target: "[\"cfe-usersguide\", \"osal-apiguide\", \"mission-doc\"]"
-      cache-key: cfs-doc-${{ github.run_number }}      
+      cache-key: cfs-doc-${{ github.run_number }}
       deploy: false
 
   deploy-documentation:
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
 

--- a/.github/workflows/build-run-app.yml
+++ b/.github/workflows/build-run-app.yml
@@ -58,13 +58,13 @@ jobs:
           fi
 
       - name: Checkout Bundle Main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
           repository: nasa/cFS
 
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: apps/${{  env.APP_LOWER  }}
 
@@ -93,7 +93,7 @@ jobs:
           ../host/cmdUtil --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
 
       - name: Archive results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cFS_startup_log
           path: cFS_startup_cpu1.txt

--- a/.github/workflows/cfs-wiki.yml
+++ b/.github/workflows/cfs-wiki.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
-      
+
       - name: create CCB agenda
         run: python3 .github/scripts/create_ccb_agenda.py
         env:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,6 +1,6 @@
 name: Changelog
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -9,31 +9,30 @@ on:
 defaults:
   run:
     shell: bash
-    
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      
+      - uses: actions/checkout@v3
+
       - name: Run Changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          issuesLabel: "### Closed issues" 
-          breakingLabel: "### Breaking changes" 
-          enhancementLabel: "### Implemented enhancements" 
-          bugsLabel: "### Fixed bugs" 
-          deprecatedLabel: "### Deprecated" 
-          removedLabel: "### Removed" 
+          issuesLabel: "### Closed issues"
+          breakingLabel: "### Breaking changes"
+          enhancementLabel: "### Implemented enhancements"
+          bugsLabel: "### Fixed bugs"
+          deprecatedLabel: "### Deprecated"
+          removedLabel: "### Removed"
           securityLabel: "### Security fixes"
           pullRequests: false
           author: false
-        
+
       - name: "Upload changelog"
         uses: actions/upload-artifact@v1.0.0
         with:
           name: "Changelog"
           path: CHANGELOG.md
-          

--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -34,10 +34,10 @@ on:
         default: cp ./cfe/cmake/Makefile.sample Makefile && cp -r ./cfe/cmake/sample_defs sample_defs
         required: false
 
-      test: 
+      test:
         description: 'Value for ENABLE_UNIT_TESTS flag'
         type: string
-        default: false 
+        default: false
         required: false
 
 # Force bash to apply pipefail option so pipeline failures aren't masked
@@ -53,7 +53,7 @@ env:
   REPO: ${{github.event.repository.name}}
 
 jobs:
-  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action.
   check-for-duplicates:
     runs-on: ubuntu-20.04
     # Map a step output to a job output
@@ -97,20 +97,20 @@ jobs:
           cd cFS
           echo "BUILD_DIRECTORY=$(pwd)" >> $GITHUB_ENV
           git log -1 --pretty=oneline
-          git submodule 
+          git submodule
           rm -r .git
-          rm -rf ${{ inputs.component-path }} 
-          ln -s ${{github.workspace}} ${{ inputs.component-path }} 
+          rm -rf ${{ inputs.component-path }}
+          ln -s ${{github.workspace}} ${{ inputs.component-path }}
 
-      
+
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v2
-        with: 
+        uses: actions/checkout@v3
+        with:
            submodules: recursive
 
         # Setup the build system
-      - name: cFS Build Setup    
-        run: | 
+      - name: cFS Build Setup
+        run: |
           ${{ inputs.setup }}
           ${{ inputs.prep }}
         working-directory: ${{env.BUILD_DIRECTORY}}
@@ -132,12 +132,12 @@ jobs:
           category: ${{matrix.scan-type}}
           upload: false
           output: CodeQL-Sarif-${{ matrix.scan-type }}
-          
+
       - name: Rename Sarif
         run: |
           mv CodeQL-Sarif-${{ matrix.scan-type }}/cpp.sarif CodeQL-Sarif-${{ matrix.scan-type }}/Codeql-${{ matrix.scan-type }}.sarif
           sed -i 's/"name" : "CodeQL"/"name" : "CodeQL-${{ matrix.scan-type }}"/g' CodeQL-Sarif-${{ matrix.scan-type }}/Codeql-${{ matrix.scan-type }}.sarif
-          
+
       - name: filter-sarif
         uses: zbazztian/filter-sarif@master
         with:
@@ -147,9 +147,9 @@ jobs:
                 -**/*.dox
             input: CodeQL-Sarif-${{ matrix.scan-type }}/Codeql-${{ matrix.scan-type }}.sarif
             output: CodeQL-Sarif-${{ matrix.scan-type }}/Codeql-${{ matrix.scan-type }}.sarif
-            
+
       - name: Archive Sarif
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: CodeQL-Sarif-${{ matrix.scan-type }}
           path: CodeQL-Sarif-${{ matrix.scan-type }}

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -79,7 +79,7 @@ jobs:
     steps:
       # Check github pull-request title against the pattern.
       - name: Check pull-request title
-        uses: gsactions/commit-message-checker@v1
+        uses: gsactions/commit-message-checker@v2
         with:
           pattern: '^((Fix|HotFix|Part)\s\#[0-9]+,\s[a-zA-Z0-9]+|Merge\spull\srequest\s\#[0-9]+\s[a-zA-Z0-9]+|IC:\s[a-zA-Z0-9]+)'
           error: 'You need at least one "Fix|HotFix|Part #<issue number>, <short description>" line in the pull-request title.'
@@ -88,7 +88,7 @@ jobs:
           checkAllCommitMessages: 'false'
       # Check each commit message associated with the pull-request against the pattern.
       - name: Check each commit message
-        uses: gsactions/commit-message-checker@v1
+        uses: gsactions/commit-message-checker@v2
         if: always()
         with:
           pattern: '^((Fix|HotFix|Part)\s\#[0-9]+,\s[a-zA-Z0-9]+|Merge\spull\srequest\s\#[0-9]+\s[a-zA-Z0-9]+|IC:\s[a-zA-Z0-9]+)'

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -10,9 +10,9 @@ on:
 defaults:
   run:
     shell: bash
-  
+
 jobs:
-  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action.
   check-for-duplicates:
     runs-on: ubuntu-latest
     # Map a step output to a job output
@@ -25,7 +25,7 @@ jobs:
           concurrent_skipping: 'same_content'
           skip_after_successful_duplicate: 'true'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
-          
+
   format-checker:
     name: Run format check
     #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
@@ -40,12 +40,12 @@ jobs:
           sudo apt-get update && sudo apt-get install clang-format
 
       - name: Checkout bundle
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: nasa/cFS
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: repo
 
@@ -56,7 +56,7 @@ jobs:
           git diff > $GITHUB_WORKSPACE/style_differences.txt
 
       - name: Archive Static Analysis Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: style_differences
           path: style_differences.txt

--- a/.github/workflows/static-analysis-misra.yml
+++ b/.github/workflows/static-analysis-misra.yml
@@ -23,7 +23,7 @@ jobs:
           concurrent_skipping: 'same_content'
           skip_after_successful_duplicate: 'true'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
-          
+
   misra-analysis:
     #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
     needs: check-for-duplicates
@@ -42,7 +42,7 @@ jobs:
 
         # Checks out a copy of the cfs bundle
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -53,11 +53,11 @@ jobs:
             cp cppcheck/addons/misra.py misra.py
             cp cppcheck/addons/cppcheckdata.py cppcheckdata.py
             cp cppcheck/addons/misra_9.py misra_9.py
-  
+
       - name: Run bundle cppcheck
         if: ${{matrix.cppcheck =='bundle'}}
         run: |
-          cppcheck --addon=misra --force --inline-suppr --quiet . --xml 2> ${{matrix.cppcheck}}_cppcheck_err.xml 
+          cppcheck --addon=misra --force --inline-suppr --quiet . --xml 2> ${{matrix.cppcheck}}_cppcheck_err.xml
           cppcheck --addon=misra --force --inline-suppr --quiet . 2> ${{matrix.cppcheck}}_cppcheck_err.txt
 
         # Run strict static analysis for embedded portions of cfe, osal, and psp
@@ -67,14 +67,14 @@ jobs:
           cd ${{matrix.cppcheck}}
           cppcheck --addon=misra --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./modules/core_api/fsw ./modules/core_private/fsw ./modules/es/fsw ./modules/evs/fsw ./modules/fs/fsw ./modules/msg/fsw ./modules/resourceid/fsw ./modules/sb/fsw ./modules/sbr/fsw ./modules/tbl/fsw ./modules/time/fsw -UCFE_PLATFORM_TIME_CFG_CLIENT -DCFE_PLATFORM_TIME_CFG_SERVER --xml 2> ${{matrix.cppcheck}}_cppcheck_err.xml
           cppcheck --addon=misra --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./modules/core_api/fsw ./modules/core_private/fsw ./modules/es/fsw ./modules/evs/fsw ./modules/fs/fsw ./modules/msg/fsw ./modules/resourceid/fsw ./modules/sb/fsw ./modules/sbr/fsw ./modules/tbl/fsw ./modules/time/fsw -UCFE_PLATFORM_TIME_CFG_CLIENT -DCFE_PLATFORM_TIME_CFG_SERVER 2> ${{matrix.cppcheck}}_cppcheck_err.txt
-          
+
       - name: osal strict cppcheck
         if: ${{matrix.cppcheck =='osal'}}
         run: |
           cd ${{matrix.cppcheck}}
           cppcheck --addon=misra --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./src/bsp ./src/os --xml 2> ${{matrix.cppcheck}}_cppcheck_err.xml
           cppcheck --addon=misra --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./src/bsp ./src/os 2> ${{matrix.cppcheck}}_cppcheck_err.txt
-          
+
       - name: psp strict cppcheck
         if: ${{matrix.cppcheck =='psp'}}
         run: |
@@ -82,22 +82,22 @@ jobs:
           cppcheck --addon=misra --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./fsw --xml 2> ${{matrix.cppcheck}}_cppcheck_err.xml
           cppcheck --addon=misra --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./fsw 2> ${{matrix.cppcheck}}_cppcheck_err.txt
 
-      - name: Convert bundle cppcheck to sarif 
+      - name: Convert bundle cppcheck to sarif
         uses: airtower-luna/convert-to-sarif@v0.2.0
         if: ${{matrix.cppcheck =='bundle'}}
         with:
           tool: 'CppCheck'
           input_file: '${{matrix.cppcheck}}_cppcheck_err.xml'
           sarif_file: '${{matrix.cppcheck}}_cppcheck_err.sarif'
-          
-      - name: Convert cfe, osal, psp cppcheck to sarif 
+
+      - name: Convert cfe, osal, psp cppcheck to sarif
         uses: airtower-luna/convert-to-sarif@v0.2.0
         if: ${{matrix.cppcheck !='bundle'}}
         with:
           tool: 'CppCheck'
           input_file: '${{matrix.cppcheck}}/${{matrix.cppcheck}}_cppcheck_err.xml'
           sarif_file: '${{matrix.cppcheck}}_cppcheck_err.sarif'
-          
+
       - name: Define workspace
         run: |
           echo "CONTAINER_WORKSPACE=${PWD}" >> ${GITHUB_ENV}
@@ -115,7 +115,7 @@ jobs:
         with:
           name: ${{matrix.cppcheck}}-cppcheck-err
           path: ./${{matrix.cppcheck}}/*cppcheck_err.*
-          
+
       - name: Upload sarif results
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/.github/workflows/unit-test-coverage.yml
+++ b/.github/workflows/unit-test-coverage.yml
@@ -58,13 +58,13 @@ jobs:
           echo "APP_LOWER=$(echo ${{ inputs.app-name }} | sed 's/[A-Z]/\L&/g')" >> $GITHUB_ENV
 
       - name: Checkout Bundle Main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
           repository: nasa/cFS
 
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: apps/${{  env.APP_LOWER  }}
 
@@ -116,7 +116,7 @@ jobs:
       - name: Archive results
         # Upload if success or failure which supports skipping, unlike always()
         if: success() || failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Unit test and coverage results
           path: |


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Update cache, checkout, and upload-artifact actions from v2 to v3. Should be a drop-in replacement and removes a warning about node.js 12 deprecation.

Fixes #621

**Testing performed**
Run all github workflows

**Expected behavior changes**
No more warnings about node.js 12 deprecation

**System(s) tested on**
Github hosted runner

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
