### PR TITLE
Fix #623, show stderr output on doc build workflow

### DIFF
--- a/.github/workflows/build-deploy-doc.yml
+++ b/.github/workflows/build-deploy-doc.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Add Repo To Build
         if: ${{ inputs.app-name != '' }}
-        run: sed -i '/list(APPEND MISSION_GLOBAL_APPLIST/a list(APPEND MISSION_GLOBAL_APPLIST ${{ inputs.app-name }})' sample_defs/targets.cmake 
+        run: echo 'set(MISSION_GLOBAL_APPLIST ${{ inputs.app-name }})' >> sample_defs/targets.cmake
 
       - name: Make Prep
         run: make prep
@@ -112,7 +112,7 @@ jobs:
 
       - name: Build Document
         run: |
-          make -C build ${{ matrix.target }} > ${{ matrix.target }}_stdout.txt 2> ${{ matrix.target }}_stderr.txt
+          make -C build ${{ matrix.target }} 2>&1 > ${{ matrix.target }}_stdout.txt | tee ${{ matrix.target }}_stderr.txt
           mv build/docs/${{ matrix.target }}/${{ matrix.target }}-warnings.log .
 
       - name: Archive Document Build Logs


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Tee the stderr output to the console, so if the "Build Documentation" step fails in this workflow, the errors will be visible in the log.

Without this, the errors are hidden in a file that is never shown nor uploaded so it cannot be seen what went wrong.

Fixes #623

**Testing performed**
Build documentation

**Expected behavior changes**
If an error occurs, the error will be visible in the workflow run log.

**System(s) tested on**
Github hosted runner

**Additional context**
This also makes a minor change to setting the applist to simplify the script and also make it a bit more robust (this does not need to update an existing line, it can just set the value, and thus does not depend on the line already being there to begin with).

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.