### PR TITLE
Fix #624, add compatibility for CFS app doc build

### DIFF
--- a/.github/workflows/build-deploy-doc.yml
+++ b/.github/workflows/build-deploy-doc.yml
@@ -29,6 +29,11 @@ on:
         type: boolean
         required: false
         default: true
+      needs_osal_api:
+        description: Whether this depends on the osal public api (compatibility bridge)
+        type: boolean
+        required: false
+        default: true
 
 # Force bash to apply pipefail option so pipeline failures aren't masked
 defaults:
@@ -109,6 +114,10 @@ jobs:
         if: ${{ inputs.buildpdf == true }}
         run: |
           sudo apt-get install texlive-latex-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra
+
+      - name: Generate OSAL header list
+        if: ${{ inputs.needs_osal_api == true }}
+        run: make -C build osal_public_api_headerlist
 
       - name: Build Document
         run: |


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Explicitly pre-build the "osal_public_api_headerlist" target which will fix documenation workflows that have not been updated to include this dependency.

Fixes #624

**Testing performed**
Build documentation

**Expected behavior changes**
CFS app doc builds should now all work again, until they can be updated properly

**System(s) tested on**
Github hosted runner

**Additional context**
This is gated by a boolean to make it easier to run app builds WITHOUT this, in order to test the workflow after putting in the real fix.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
