### PR TITLE
Fix #631, Remove README link to empty fs_lib repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,6 @@ The following list is user submitted, and not CCB controlled.  They are released
     - cFS_IO_LIB: IO library at https://github.com/nasa/CFS_IO_LIB
     - cFS_LIB: at https://github.com/nasa/cfs_lib
     - EdsLib: CCSDS SOIS Electronic Data Sheet Tool and Library at https://github.com/nasa/EdsLib
-    - fs_lib: File services library at https://github.com/nasa/fs_lib
   - Other Tools
     - CTF: cFS Test Framework at https://github.com/nasa/CTF
     - CCDD: Command and Data Dictionary Tool at https://github.com/nasa/CCDD


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #631
Removes link to empty fs_lib repository

**Expected behavior changes**
None

**Contributor Info**
Avi Weiss @thnkslprpt