### PR TITLE
Fix #662, Removes error on format style differences

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -61,14 +61,6 @@ jobs:
           name: style_differences
           path: style_differences.txt
 
-      - name: Error on differences
-        run: |
-          if [[ -s style_differences.txt ]];
-          then
-            cat style_differences.txt
-            exit -1
-          fi
-
   check-commit-message:
     name: Check Commit Message
     needs: check-for-duplicates


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #662
   - Removes the exiting logic such that the workflow can't fail due to a claang difference.

**Testing performed**
Observed that error does not happen when format-check is called and there is a claang-format-10 style difference.

**Expected behavior changes**
No error on style differences

**System(s) tested on**
 - OS: Ubuntu 20.04

**Additional context**
N/A

**Code contributions**
The cFS repository is provided to bundle the cFS Framework.  It is utilized for bundling submodules, continuous integration testing, and version management and does not contain any software.  Code contributions should be directed to the appropriate submodule.

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage
