### PR TITLE
Fix #679, Increase wait time in test workflow

### DIFF
--- a/.github/workflows/build-cfs-deprecated.yml
+++ b/.github/workflows/build-cfs-deprecated.yml
@@ -198,7 +198,7 @@ jobs:
             fi
             counter=$(grep -c "BEGIN" cf/cfe_test.tmp)
             echo "Waiting for CFE Tests"
-            sleep 60
+            sleep 120
           done
 
           ../host/cmdUtil --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002

--- a/.github/workflows/build-cfs.yml
+++ b/.github/workflows/build-cfs.yml
@@ -196,7 +196,7 @@ jobs:
             fi
             counter=$(grep -c "BEGIN" cf/cfe_test.tmp)
             echo "Waiting for CFE Tests"
-            sleep 60
+            sleep 120
           done
 
           ../host/cmdUtil --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x ] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Increase the wait time required to call a test 'frozen'. This will prevent tests from erroneously being called 'frozen' and allow the tests to complete successfully..
Fixes Issue #679 

**Testing performed**
Executed tests to ensure each tests completes in the allotted time.

**Contributor Info - All information REQUIRED for consideration of pull request**
Dan Knutsen
NASA Goddard
