### PR TITLE
Fix #742, Adds node20 compatible github actions

### DIFF
--- a/.github/workflows/build-cfs-deprecated.yml
+++ b/.github/workflows/build-cfs-deprecated.yml
@@ -50,14 +50,14 @@ jobs:
     steps:
       - name: Cache Source and Build
         id: cache-src-bld
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/*
           key: deprecated-build-${{ github.run_number }}-${{ matrix.buildtype }}
 
       - name: Checkout cFS
         if: steps.cache-src-bld.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -96,7 +96,7 @@ jobs:
 
       - name: Cache Source and Deprecated Build
         id: cache-src-bld
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/*
           key: deprecated-build-${{ github.run_number }}-${{ matrix.buildtype }}
@@ -124,7 +124,7 @@ jobs:
     steps:
       - name: Cache Source and Deprecated Build
         id: cache-src-bld
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/*
           key: deprecated-build-${{ github.run_number }}-${{ matrix.buildtype }}
@@ -141,7 +141,7 @@ jobs:
         working-directory: ./build/exe/cpu1/
 
       - name: Archive cFS Startup Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cFS-startup-log-omit-deprecate-false${{ matrix.buildtype }}
           path: ./build/exe/cpu1/cFS_startup_cpu1.txt
@@ -171,7 +171,7 @@ jobs:
     steps:
       - name: Cache Source and Deprecated Build
         id: cache-src-bld
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/*
           key: deprecated-build-${{ github.run_number }}-${{ matrix.buildtype }}
@@ -205,7 +205,7 @@ jobs:
         working-directory: ./build/exe/cpu1/
 
       - name: Archive Functional Test Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cFS-functional-test-log-omit-deprecate-false-${{ matrix.buildtype }}
           path: ./build/exe/cpu1/cf/cfe_test.log

--- a/.github/workflows/build-cfs-rtems4.11.yml
+++ b/.github/workflows/build-cfs-rtems4.11.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       # Check out the cfs bundle
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -92,7 +92,7 @@ jobs:
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -124,7 +124,7 @@ jobs:
 
       # Always archive test logs
       - name: Archive cFS Test Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         # Runs even if previous steps have failed
         if: always()
         with:

--- a/.github/workflows/build-cfs-rtems5.yml
+++ b/.github/workflows/build-cfs-rtems5.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       # Check out the cfs bundle
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -92,7 +92,7 @@ jobs:
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -122,7 +122,7 @@ jobs:
 
       # Always archive test logs
       - name: Archive cFS Test Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         # Runs even if previous steps have failed
         if: always()
         with:

--- a/.github/workflows/build-cfs.yml
+++ b/.github/workflows/build-cfs.yml
@@ -50,14 +50,14 @@ jobs:
     steps:
       - name: Cache Source and Build
         id: cache-src-bld
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/*
           key: build-${{ github.run_number }}-${{ matrix.buildtype }}
 
       - name: Checkout cFS
         if: steps.cache-src-bld.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -95,7 +95,7 @@ jobs:
 
       - name: Cache Source and Build
         id: cache-src-bld
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/*
           key: build-${{ github.run_number }}-${{ matrix.buildtype }}
@@ -123,7 +123,7 @@ jobs:
     steps:
       - name: Cache Source and Build
         id: cache-src-bld
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/*
           key: build-${{ github.run_number }}-${{ matrix.buildtype }}
@@ -140,7 +140,7 @@ jobs:
         working-directory: ./build/exe/cpu1/
 
       - name: Archive cFS Startup Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cFS-startup-log-omit-deprecate-true-${{ matrix.buildtype }}
           path: ./build/exe/cpu1/cFS_startup_cpu1.txt
@@ -169,7 +169,7 @@ jobs:
     steps:
       - name: Cache Source and Build
         id: cache-src-bld
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/*
           key: build-${{ github.run_number }}-${{ matrix.buildtype }}
@@ -203,7 +203,7 @@ jobs:
         working-directory: ./build/exe/cpu1/
 
       - name: Archive cFS Startup Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cFS-functional-test-log-omit-deprecate-true-${{ matrix.buildtype }}
           path: ./build/exe/cpu1/cf/cfe_test.log

--- a/.github/workflows/build-deploy-doc.yml
+++ b/.github/workflows/build-deploy-doc.yml
@@ -77,21 +77,21 @@ jobs:
       - name: Get cache if supplied
         id: cache-src-bld
         if: ${{ inputs.cache-key != '' }}
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/*
           key: ${{ inputs.cache-key }}
 
       - name: Checkout Bundle Main
         if: ${{ inputs.app-name != '' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           repository: nasa/cFS
 
       - name: Checkout Repo
         if: ${{ inputs.app-name != '' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: apps/${{ inputs.app-name }}
 
@@ -158,7 +158,7 @@ jobs:
 
       - name: Archive PDF
         if: ${{ inputs.buildpdf == true }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}_pdf
           path: ./deploy/${{ matrix.target }}.pdf

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -33,13 +33,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: Cache Source and Build
         id: cache-src-bld
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/*
           key: cfs-doc-${{ github.run_number }}
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v3
 

--- a/.github/workflows/build-run-app.yml
+++ b/.github/workflows/build-run-app.yml
@@ -58,13 +58,13 @@ jobs:
           fi
 
       - name: Checkout Bundle Main
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           repository: nasa/cFS
 
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: apps/${{  env.APP_LOWER  }}
 
@@ -93,7 +93,7 @@ jobs:
           ../host/cmdUtil --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
 
       - name: Archive results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cFS_startup_log
           path: cFS_startup_cpu1.txt

--- a/.github/workflows/cfs-wiki.yml
+++ b/.github/workflows/cfs-wiki.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -26,7 +26,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Archive CCB agenda artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ccb-agenda
           path: ./CCBAgenda.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run Changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.1.1

--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -104,7 +104,7 @@ jobs:
 
 
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            submodules: recursive
 
@@ -116,7 +116,7 @@ jobs:
         working-directory: ${{env.BUILD_DIRECTORY}}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: cpp
           config-file: nasa/cFS/.github/codeql/codeql-${{matrix.scan-type}}.yml@main
@@ -126,7 +126,7 @@ jobs:
         working-directory: ${{env.BUILD_DIRECTORY}}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           add-snippets: true
           category: ${{matrix.scan-type}}
@@ -149,12 +149,12 @@ jobs:
             output: CodeQL-Sarif-${{ matrix.scan-type }}/Codeql-${{ matrix.scan-type }}.sarif
 
       - name: Archive Sarif
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: CodeQL-Sarif-${{ matrix.scan-type }}
           path: CodeQL-Sarif-${{ matrix.scan-type }}
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: CodeQL-Sarif-${{ matrix.scan-type }}/Codeql-${{ matrix.scan-type }}.sarif

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -40,12 +40,12 @@ jobs:
           sudo apt-get update && sudo apt-get install clang-format
 
       - name: Checkout bundle
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: nasa/cFS
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: repo
 
@@ -56,7 +56,7 @@ jobs:
           git diff > $GITHUB_WORKSPACE/style_differences.txt
 
       - name: Archive Static Analysis Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: style_differences
           path: style_differences.txt

--- a/.github/workflows/static-analysis-misra.yml
+++ b/.github/workflows/static-analysis-misra.yml
@@ -42,7 +42,7 @@ jobs:
 
         # Checks out a copy of the cfs bundle
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -103,21 +103,21 @@ jobs:
           echo "CONTAINER_WORKSPACE=${PWD}" >> ${GITHUB_ENV}
 
       - name: Archive bundle static analysis artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{matrix.cppcheck =='bundle'}}
         with:
           name: ${{matrix.cppcheck}}-cppcheck-err
           path: ./*cppcheck_err.*
 
       - name: Archive osal, cfe, and psp static analysis artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{matrix.cppcheck !='bundle'}}
         with:
           name: ${{matrix.cppcheck}}-cppcheck-err
           path: ./${{matrix.cppcheck}}/*cppcheck_err.*
 
       - name: Upload sarif results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: '${{matrix.cppcheck}}_cppcheck_err.sarif'
           checkout_path: ${{ env.CONTAINER_WORKSPACE }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -61,7 +61,7 @@ jobs:
 
         # Checks out a copy of the reference repository
       - name: Checkout subject repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: source
           submodules: true
@@ -104,14 +104,14 @@ jobs:
         run: xsltproc cppcheck-xml2text.xslt cppcheck_err.xml | tee $GITHUB_STEP_SUMMARY cppcheck_err.txt
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ github.workspace }}/cppcheck_err.sarif
           checkout_path: ${{ github.workspace }}/source
           category: 'cppcheck'
 
       - name: Archive static analysis artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cppcheck-errors
           path: ./*cppcheck_err.*

--- a/.github/workflows/unit-test-coverage.yml
+++ b/.github/workflows/unit-test-coverage.yml
@@ -58,13 +58,13 @@ jobs:
           echo "APP_LOWER=$(echo ${{ inputs.app-name }} | sed 's/[A-Z]/\L&/g')" >> $GITHUB_ENV
 
       - name: Checkout Bundle Main
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           repository: nasa/cFS
 
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: apps/${{  env.APP_LOWER  }}
 
@@ -116,7 +116,7 @@ jobs:
       - name: Archive results
         # Upload if success or failure which supports skipping, unlike always()
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Unit test and coverage results
           path: |


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #742. Adds version 4 of github actions that have node 20 compatibility. This change suppresses cFS github warnings associated with deprecated node 16 versioned actions.

**Testing performed**
https://github.com/chillfig/cFS/commit/007d6ea41ec28d320eeeb093217c1a26c6b01cf7
Tested on fork from link above using rtems containers using Ubuntu 20.04 instead of Ubuntu 18.04. 

**Expected behavior changes**
Suppresses cFS github warnings associated with deprecated node 16 versioned actions.

**System(s) tested on**
 - OS: Ubuntu 20.04

**Additional context**
https://github.com/core-flight-system/containers/pull/14 must be considered for merging before this pull request is merged. The cFS rtems github workflows must have respective Ubuntu 20.04 supported rtems container images. If this is merged without containers getting updated, cFS workflows will fail.

**Code contributions**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems
