### PR TITLE
Fix #798, Update build/test workflows to include sample/lab apps

### DIFF
--- a/.github/workflows/build-run-app.yml
+++ b/.github/workflows/build-run-app.yml
@@ -14,6 +14,11 @@ on:
         type: string
         required: false
         default: ''
+      is_framework_app:
+        description: Whether this is a framework app (TO/CI/SCH Lab, Sample App)
+        type: boolean
+        required: false
+        default: false
 
 # Force bash to apply pipefail option so pipeline failures aren't masked
 defaults:
@@ -75,12 +80,16 @@ jobs:
 
       - name: Add To Build
         run: |
-          sed -i "/list(APPEND MISSION_GLOBAL_APPLIST/a list(APPEND MISSION_GLOBAL_APPLIST $APP_LOWER)" sample_defs/targets.cmake
+          if [[ "${{ inputs.is_framework_app }}" == "false" ]]; then
+            sed -i "/list(APPEND MISSION_GLOBAL_APPLIST/a list(APPEND MISSION_GLOBAL_APPLIST $APP_LOWER)" sample_defs/targets.cmake
+          fi
 
       - name: Add To Startup
         run: |
-          sed -i "1i CFE_APP, $APP_LOWER, ${APP_UPPER}_AppMain, $APP_UPPER, 80, 16384, 0x0, 0;" sample_defs/cpu1_cfe_es_startup.scr
-          cat sample_defs/cpu1_cfe_es_startup.scr
+          if [[ "${{ inputs.is_framework_app }}" == "false" ]]; then
+            sed -i "1i CFE_APP, $APP_LOWER, ${APP_UPPER}_AppMain, $APP_UPPER, 80, 16384, 0x0, 0;" sample_defs/cpu1_cfe_es_startup.scr
+            cat sample_defs/cpu1_cfe_es_startup.scr
+          fi
 
       - name: Make install
         run: make SIMULATION=native BUILDTYPE=release OMIT_DEPRECATED=true install

--- a/.github/workflows/unit-test-coverage.yml
+++ b/.github/workflows/unit-test-coverage.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       # Optional inputs
       app-name:
-        description: Application name, if different from repo name
+        description: Application or library name, if different from repo name
         type: string
         required: false
         default: ${{ github.event.repository.name }}
@@ -19,6 +19,11 @@ on:
         type: number
         required: false
         default: 0
+      is_framework_app:
+        description: Whether this is a framework/sample app or library
+        type: boolean
+        required: false
+        default: false
 
 # Force bash to apply pipefail option so pipeline failures aren't masked
 defaults:
@@ -75,7 +80,9 @@ jobs:
 
       - name: Add Repo To Build
         run: |
-          sed -i "/list(APPEND MISSION_GLOBAL_APPLIST/a list(APPEND MISSION_GLOBAL_APPLIST $APP_LOWER)" sample_defs/targets.cmake
+          if [[ "${{ inputs.is_framework_app }}" == "false" ]]; then
+            sed -i "/list(APPEND MISSION_GLOBAL_APPLIST/a list(APPEND MISSION_GLOBAL_APPLIST $APP_LOWER)" sample_defs/targets.cmake
+          fi
 
       - name: Make Prep
         run: make SIMULATION=native ENABLE_UNIT_TESTS=true OMIT_DEPRECATED=true prep
@@ -83,7 +90,7 @@ jobs:
       - name: Build app build dependencies
         run: make -C build/tools/elf2cfetbl
 
-      - name: Build app target
+      - name: Build app/library target
         run: |
           make -C build/native/default_cpu1/apps/$APP_LOWER
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #798 
  - Jake already made these workflows highly generalised and reusable, so this PR only required a couple of minor additions to enable use of `unit-test-coverage.yml` and `build-run-app.yml` with the sample_app, sample_lib and the lab apps.

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).  
I've tested the build-run-app workflow with sample_app, sch_lab and sample_lib, and the unit-test-coverage workflow with sample_app and sample_lib - all working as expected.

**Expected behavior changes**
This PR will allow immediate notification of a regression or issue with the build/tests in the sample/lab repositories when pushing a branch or creating a PR.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt