### PR TITLE
Fix #811, Updated SECURITY.md to fix error 404 for CodeSonar link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,7 +38,7 @@ CodeSonar results are not available to the public.
 
 CodeSonar is typically ran on a “once per release” sort of schedule.  
 
-For more information about CodeSonar, visit https://www.grammatech.com/codesonar-cc.
+For more information about CodeSonar, visit https://codesecure.com/our-products/codesonar.
 
 ### Fuzz Testing
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
The URL has been updated in the markdown to redirect to the correct page for CodeSonar. The problem has to do with CodeSonar's page no longer being available on Grammatech and being moved to CodeSecure. It will no longer display a 404 error.

**Testing performed**
Steps taken to test the contribution:
1. Changes are reflected as expected in the markdown doc.
2. The URL in the markdown document now redirects to the appropriate page as seen.

**Expected behavior changes**
The URL should now redirects to the expected page.

**System(s) tested on**
 - Hardware: N/A
 - OS: N/A
 - Versions: N/A

**Additional context**
N/A

**Code contributions**
The cFS repository is provided to bundle the cFS Framework.  It is utilized for bundling submodules, continuous integration testing, and version management and does not contain any software.  Code contributions should be directed to the appropriate submodule.

**Contributor Info - All information REQUIRED for consideration of pull request**
Vineeth B V (Personal)
 - Note CLAs apply to only software contributions.
