### PR TITLE
Fix #812, Update Upload Artifact Version

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -32,7 +32,7 @@ jobs:
           author: false
 
       - name: "Upload changelog"
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: "Changelog"
           path: CHANGELOG.md


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #812 

**Testing performed**
https://github.com/arielswalker/cFS/actions/runs/12915978064

**Expected behavior changes**
Changelog workflow will not fail due to outdated upload artifacts version. 

**System(s) tested on**
GitHub Actions 

**Additional context**
This article, https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/, states:

"This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers."

Only the opensource workflows should be updated to use the latest version, v4. The internal workflows will fail if using v4 as seen below so it should continue to use v3.

This wiki, https://github.com/actions/upload-artifact, states:

"upload-artifact@v4+ is not currently supported on GHES yet. If you are on GHES, you must use [v3](https://github.com/actions/upload-artifact/releases/tag/v3)."

**Code contributions**

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH. 

