### PR TITLE
Fix #839, Update Workflows to Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-cfs-deprecated.yml
+++ b/.github/workflows/build-cfs-deprecated.yml
@@ -36,7 +36,7 @@ jobs:
     name: "[Deprecated] Build"
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -78,7 +78,7 @@ jobs:
   tests-and-coverage-omit-deprecated-false:
     name: "[Deprecated] Run Unit Tests and Check Coverage"
     needs: build-cfs-omit-deprecated-false
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -110,7 +110,7 @@ jobs:
   run-cfs-omit-deprecated-false:
     name: "[Deprecated] Run cFS"
     needs: build-cfs-omit-deprecated-false
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -160,7 +160,7 @@ jobs:
     #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
     needs: run-cfs-omit-deprecated-false
     name: "[DEPRECATED] cFS Functional Tests"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
 
     strategy:

--- a/.github/workflows/build-cfs-rtems4.11.yml
+++ b/.github/workflows/build-cfs-rtems4.11.yml
@@ -34,7 +34,7 @@ jobs:
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: ghcr.io/core-flight-system/qemu-rtems-4-11:latest
 
     strategy:
@@ -70,7 +70,7 @@ jobs:
 
   test-cfs:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: ghcr.io/core-flight-system/qemu-rtems-4-11:latest
 
     needs: build-cfs

--- a/.github/workflows/build-cfs-rtems5.yml
+++ b/.github/workflows/build-cfs-rtems5.yml
@@ -34,7 +34,7 @@ jobs:
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: ghcr.io/core-flight-system/qemu-rtems-5:latest
 
     strategy:
@@ -70,7 +70,7 @@ jobs:
 
   test-cfs:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: ghcr.io/core-flight-system/qemu-rtems-5:latest
 
     needs: build-cfs

--- a/.github/workflows/build-cfs.yml
+++ b/.github/workflows/build-cfs.yml
@@ -36,7 +36,7 @@ jobs:
     name: Build
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -77,7 +77,7 @@ jobs:
   tests-and-coverage-omit-deprecated-true:
     name: Run Unit Tests and Check Coverage
     needs: build-cfs-omit-deprecated-true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -109,7 +109,7 @@ jobs:
   run-cfs-omit-deprecated-true:
     name: Run
     needs: build-cfs-omit-deprecated-true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -158,7 +158,7 @@ jobs:
   run-functional-test-app-omit-deprecated-true:
     #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
     needs: run-cfs-omit-deprecated-true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
 
     strategy:

--- a/.github/workflows/build-deploy-doc.yml
+++ b/.github/workflows/build-deploy-doc.yml
@@ -60,7 +60,7 @@ jobs:
     needs: checks-for-duplicates
     if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' || contains(github.ref, 'main') }}
     name: Build Documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build-run-app.yml
+++ b/.github/workflows/build-run-app.yml
@@ -40,7 +40,7 @@ jobs:
     needs: checks-for-duplicates
     if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' || contains(github.ref, 'main') }}
     name: Build and run app, confirm startup message
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Set up environment variables

--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -55,7 +55,7 @@ env:
 jobs:
   #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action.
   check-for-duplicates:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -71,7 +71,7 @@ jobs:
     #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
 
     strategy:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -31,7 +31,7 @@ jobs:
     #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
 
     steps:
@@ -66,7 +66,7 @@ jobs:
     needs: check-for-duplicates
     # Only run for pull-requests.
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
       # Check each commit message associated with the pull-request against the pattern.

--- a/.github/workflows/unit-test-coverage.yml
+++ b/.github/workflows/unit-test-coverage.yml
@@ -45,7 +45,7 @@ jobs:
     needs: checks-for-duplicates
     if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' || contains(github.ref, 'main') }}
     name: Build, run unit tests and enforce coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Install coverage tools


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #839 

**Testing performed**
GitHub Actions on this PR branch. For example, https://github.com/arielswalker/cFS/actions/runs/14499022671.

**Expected behavior changes**
Workflows will not longer throw error `This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101`

**System(s) tested on**
GitHub Actions

**Additional Context**
Some workflows show as failed on this PR branch because they point to reusable workflows on the main branch that have not been updated to ubuntu-22.04 such as [CodeQL](https://github.com/arielswalker/cFS/actions/runs/14499093489). 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.
