### PR TITLE
Fix #854, add apt-get update to static analysis

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -49,7 +49,9 @@ jobs:
 
     steps:
       - name: Install cppcheck
-        run: sudo apt-get install cppcheck xsltproc -y
+        run: |
+          sudo apt-get update 
+          sudo apt-get install cppcheck xsltproc -y
 
       - name: Install sarif tool
         run: npm install @microsoft/sarif-multitool


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adding apt-get update should resolve the issues when installing the cppcheck package.

Fixes #854

**Testing performed**
Run github actions

**Expected behavior changes**
Cppcheck should work

**System(s) tested on**
Github actions

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
