### PR TITLE
Fix #853, Use Cache to Avoid Duplicate Workflow Steps

### DIFF
--- a/.github/workflows/build-cfs-rtems4.11.yml
+++ b/.github/workflows/build-cfs-rtems4.11.yml
@@ -45,10 +45,20 @@ jobs:
     # Set the type of machine to run on
     env:
       BUILDTYPE: ${{ matrix.buildtype }}
+      ENABLE_UNIT_TESTS: true
       # Set home to where rtems is located
       HOME: /root
+      # Disable mcopy check otherwise disk image build fails
+      MTOOLS_SKIP_CHECK: 1
 
     steps:
+      - name: Cache Source and Build
+        id: cache-src-bld
+        uses: actions/cache@v4
+        with:
+          path: ./
+          key: rtems4.11-build-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.buildtype }}
+
       # Check out the cfs bundle
       - name: Checkout code
         uses: actions/checkout@v4
@@ -66,7 +76,7 @@ jobs:
         run: make SIMULATION=i686-rtems4.11 prep
 
       - name: Make
-        run: make
+        run: make install
 
   test-cfs:
     name: Test
@@ -80,33 +90,13 @@ jobs:
       matrix:
         buildtype: [debug, release]
 
-    # Set the type of machine to run on
-    env:
-      BUILDTYPE: ${{ matrix.buildtype }}
-      ENABLE_UNIT_TESTS: true
-      # Set home to where rtems is located
-      HOME: /root
-      # Disable mcopy check otherwise disk image build fails
-      MTOOLS_SKIP_CHECK: 1
-
     steps:
-      # Checks out a copy of your repository on the ubuntu-latest machine
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Cache Source and Build
+        id: cache-src-bld
+        uses: actions/cache@v4
         with:
-          submodules: true
-
-      # Setup the build system
-      - name: Copy Files
-        run: |
-          cp ./cfe/cmake/Makefile.sample Makefile
-          cp -r ./cfe/cmake/sample_defs sample_defs
-
-      # Setup the build system
-      - name: Make
-        run: |
-          make SIMULATION=i686-rtems4.11 prep
-          make install
+          path: ./
+          key: rtems4.11-build-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.buildtype }}
 
       - name: Test
         #run: .github/scripts/qemu_test.sh && .github/scripts/log_failed_tests.sh

--- a/.github/workflows/build-cfs-rtems5.yml
+++ b/.github/workflows/build-cfs-rtems5.yml
@@ -45,10 +45,20 @@ jobs:
     # Set the type of machine to run on
     env:
       BUILDTYPE: ${{ matrix.buildtype }}
+      ENABLE_UNIT_TESTS: true
       # Set home to where rtems is located
       HOME: /root
+      # Disable mcopy check otherwise disk image build fails
+      MTOOLS_SKIP_CHECK: 1
 
     steps:
+      - name: Cache Source and Build
+        id: cache-src-bld
+        uses: actions/cache@v4
+        with:
+          path: ./
+          key: rtems5-build-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.buildtype }}
+
       # Check out the cfs bundle
       - name: Checkout code
         uses: actions/checkout@v4
@@ -66,7 +76,7 @@ jobs:
         run: make SIMULATION=i686-rtems5 prep
 
       - name: Make
-        run: make
+        run: make install
 
   test-cfs:
     name: Test
@@ -80,33 +90,13 @@ jobs:
       matrix:
         buildtype: [debug, release]
 
-    # Set the type of machine to run on
-    env:
-      BUILDTYPE: ${{ matrix.buildtype }}
-      ENABLE_UNIT_TESTS: true
-      # Set home to where rtems is located
-      HOME: /root
-      # Disable mcopy check otherwise disk image build fails
-      MTOOLS_SKIP_CHECK: 1
-
     steps:
-      # Checks out a copy of your repository on the ubuntu-latest machine
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Cache Source and Build
+        id: cache-src-bld
+        uses: actions/cache@v4
         with:
-          submodules: true
-
-      # Setup the build system
-      - name: Copy Files
-        run: |
-          cp ./cfe/cmake/Makefile.sample Makefile
-          cp -r ./cfe/cmake/sample_defs sample_defs
-
-      # Setup the build system
-      - name: Make
-        run: |
-          make SIMULATION=i686-rtems5 prep
-          make install
+          path: ./
+          key: rtems5-build-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.buildtype }}
 
       - name: Test
         #run: .github/scripts/qemu_test.sh && .github/scripts/log_failed_tests.sh


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #853

**Testing performed**
[RTEMS 4.11](https://github.com/nasa/cFS/actions/runs/16813560649)
[RTEMS 5](https://github.com/nasa/cFS/actions/runs/16813560610)

**Expected behavior changes**
The RTEMS workflows should not checkout code, prep, and make twice for the Build and Test jobs. Instead it should perform those steps once in Build job and cache it for the Test job.

**System(s) tested on**
GitHub Actions

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.
