### PR TITLE
Fix #842, Update Workflows to Use ubuntu-latest Tag

### DIFF
--- a/.github/workflows/build-cfs-deprecated.yml
+++ b/.github/workflows/build-cfs-deprecated.yml
@@ -36,7 +36,7 @@ jobs:
     name: "[Deprecated] Build"
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -78,7 +78,7 @@ jobs:
   tests-and-coverage-omit-deprecated-false:
     name: "[Deprecated] Run Unit Tests and Check Coverage"
     needs: build-cfs-omit-deprecated-false
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -110,7 +110,7 @@ jobs:
   run-cfs-omit-deprecated-false:
     name: "[Deprecated] Run cFS"
     needs: build-cfs-omit-deprecated-false
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -160,7 +160,7 @@ jobs:
     #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
     needs: run-cfs-omit-deprecated-false
     name: "[DEPRECATED] cFS Functional Tests"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:

--- a/.github/workflows/build-cfs-rtems4.11.yml
+++ b/.github/workflows/build-cfs-rtems4.11.yml
@@ -34,7 +34,7 @@ jobs:
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: ghcr.io/core-flight-system/qemu-rtems-4-11:latest
 
     strategy:
@@ -70,7 +70,7 @@ jobs:
 
   test-cfs:
     name: Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: ghcr.io/core-flight-system/qemu-rtems-4-11:latest
 
     needs: build-cfs

--- a/.github/workflows/build-cfs-rtems5.yml
+++ b/.github/workflows/build-cfs-rtems5.yml
@@ -34,7 +34,7 @@ jobs:
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: ghcr.io/core-flight-system/qemu-rtems-5:latest
 
     strategy:
@@ -70,7 +70,7 @@ jobs:
 
   test-cfs:
     name: Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: ghcr.io/core-flight-system/qemu-rtems-5:latest
 
     needs: build-cfs

--- a/.github/workflows/build-cfs.yml
+++ b/.github/workflows/build-cfs.yml
@@ -36,7 +36,7 @@ jobs:
     name: Build
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -77,7 +77,7 @@ jobs:
   tests-and-coverage-omit-deprecated-true:
     name: Run Unit Tests and Check Coverage
     needs: build-cfs-omit-deprecated-true
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -109,7 +109,7 @@ jobs:
   run-cfs-omit-deprecated-true:
     name: Run
     needs: build-cfs-omit-deprecated-true
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -158,7 +158,7 @@ jobs:
   run-functional-test-app-omit-deprecated-true:
     #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
     needs: run-cfs-omit-deprecated-true
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:

--- a/.github/workflows/build-deploy-doc.yml
+++ b/.github/workflows/build-deploy-doc.yml
@@ -60,7 +60,7 @@ jobs:
     needs: checks-for-duplicates
     if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' || contains(github.ref, 'main') }}
     name: Build Documentation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build-run-app.yml
+++ b/.github/workflows/build-run-app.yml
@@ -40,7 +40,7 @@ jobs:
     needs: checks-for-duplicates
     if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' || contains(github.ref, 'main') }}
     name: Build and run app, confirm startup message
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Set up environment variables

--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -55,7 +55,7 @@ env:
 jobs:
   #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action.
   check-for-duplicates:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -71,7 +71,7 @@ jobs:
     #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -31,7 +31,7 @@ jobs:
     #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:
@@ -66,7 +66,7 @@ jobs:
     needs: check-for-duplicates
     # Only run for pull-requests.
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       # Check each commit message associated with the pull-request against the pattern.

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -42,7 +42,7 @@ jobs:
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
     name: Run cppcheck
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/.github/workflows/unit-test-coverage.yml
+++ b/.github/workflows/unit-test-coverage.yml
@@ -45,7 +45,7 @@ jobs:
     needs: checks-for-duplicates
     if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' || contains(github.ref, 'main') }}
     name: Build, run unit tests and enforce coverage
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Install coverage tools


### PR DESCRIPTION
**Checklist (Please check before submitting)**

- [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md)
- [x] I signed the [CLA](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) and emailed it to GSFC-SoftwareRelease@mail.nasa.gov and cfs-program@lists.nasa.gov

**Describe the contribution**

Fix #842

Replaces all hardcoded `ubuntu-22.04` runner references with the `ubuntu-latest` tag across 10 workflow files in the cFS bundle repository.

**Testing performed**

- Verified all YAML workflow files pass syntax validation
- Confirmed no remaining `ubuntu-22.04` references in `.github/workflows/`
- Changes are isolated to `runs-on:` directives only (~20 line replacements)

**Expected behavior changes**

Workflows will automatically use the latest GitHub-hosted Ubuntu runner image. This:
- Enables leverage of newer runner images as GitHub updates them
- Eliminates future maintenance when Ubuntu 22.04 reaches end-of-life
- Aligns with the existing pattern where `check-for-duplicates` jobs which ALREADY use `ubuntu-latest`

**System(s) tested on**

GitHub Actions (workflow syntax validation)

**Additional context**

Files modified:
- `build-cfs.yml`
- `build-cfs-deprecated.yml`
- `build-cfs-rtems4.11.yml`
- `build-cfs-rtems5.yml`
- `codeql-reusable.yml`
- `format-check.yml`
- `build-deploy-doc.yml`
- `build-run-app.yml`
- `static-analysis.yml`
- `unit-test-coverage.yml`

**Contributor Info**

Heath Dutton, Individual Contributor @heathdutton