### PR TITLE
Fix #875, Disable build-mission-doc workflow and remove README link

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -57,7 +57,7 @@ jobs:
     name: Build cFS documents
     uses: nasa/cFS/.github/workflows/build-deploy-doc.yml@main
     with:
-      target: "[\"cfe-usersguide\", \"osal-apiguide\", \"mission-doc\"]"
+      target: "[\"cfe-usersguide\", \"osal-apiguide\"]"
       cache-key: cfs-doc-${{ github.run_id }}-${{ github.run_attempt }}
       deploy: false
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ More information is available on the [cFS Website](<https://cfs.gsfc.nasa.gov>).
 
 - [cFE User's Guide](<https://github.com/nasa/cFS/blob/gh-pages/cfe-usersguide.pdf>)
 - [OSAL User's Guide](<https://github.com/nasa/cFS/blob/gh-pages/osal-apiguide.pdf>)
-- [Combined Mission documentation](<https://github.com/nasa/cFS/blob/gh-pages/mission-doc.pdf>)
 - [cFE App Developer's Guide](<https://github.com/nasa/cFE/blob/main/docs/cFE%20Application%20Developers%20Guide.md>)
 - [Training documentation](<https://ntrs.nasa.gov/citations/20240000217>)
 - [cFS Overview](<https://cfs.gsfc.nasa.gov/cFS-OviewBGSlideDeck-ExportControl-Final.pdf>)


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**

- Fix #875
- https://github.com/nasa/cFS/actions/runs/21296014369/job/61301835049

**Testing performed**

- pipeline work in progress

**Expected behavior changes**
- pipeline passes (TBD)

**System(s) tested on**
- github.com workflows

**Additional context**
N/A

**Code contributions**
The cFS repository is provided to bundle the cFS Framework.  It is utilized for bundling submodules, continuous integration testing, and version management and does not contain any software.  Code contributions should be directed to the appropriate submodule.

**Contributor Info - All information REQUIRED for consideration of pull request**
Keegan Moore / NASA GSFC
