### PR TITLE
Fix #965, Update .clang-format to Match Internal File

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,45 +1,85 @@
 ---
-Language:        Cpp
-AccessModifierOffset: -4
+BasedOnStyle: Google
+AccessModifierOffset: '-4'
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: true
-AlignConsecutiveDeclarations: true
-AlignConsecutiveMacros: true
+AlignArrayOfStructures: Left
+AlignConsecutiveAssignments:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: true
+  AlignCompound: true
+  PadOperators: true
+AlignConsecutiveDeclarations:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: true
+  AlignCompound: true
+  PadOperators: true
+AlignConsecutiveMacros:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: true
+  AlignCompound: true
+  PadOperators: true
 AlignEscapedNewlines: Left
-AlignOperands:   true
+AlignConsecutiveBitFields: true
+AlignOperands: true
 AlignTrailingComments: true
-AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: Empty
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: InlineOnly
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-BinPackArguments: true
-BinPackParameters: true
-BreakBeforeBinaryOperators: None
+AlwaysBreakTemplateDeclarations: 'Yes'
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: false
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: false
+  BeforeWhile: true
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Allman
 BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: AfterColon
+BreakInheritanceList: AfterColon
 BreakStringLiterals: true
-ColumnLimit:     120
-CommentPragmas:  ''
-ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
+ColumnLimit: '120'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: '4'
+ContinuationIndentWidth: '4'
+Cpp11BracedListStyle: false
 DerivePointerAlignment: false
-DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
-ForEachMacros: []
-IncludeBlocks:   Preserve
-IncludeCategories:  []
-IncludeIsMainRegex: '$'
+FixNamespaceComments: true
+IncludeBlocks: Preserve
 IndentCaseLabels: true
 IndentPPDirectives: None
-IndentWidth:     4
-KeepEmptyLinesAtTheStartOfBlocks: true
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
+IndentWidth: '4'
+KeepEmptyLinesAtTheStartOfBlocks: false
+Language: Cpp
 MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
@@ -48,19 +88,24 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
-ReflowComments:  true
-SortIncludes:    false
+ReflowComments: true
+SortIncludes: false
+SortUsingDeclarations: false
 SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
-SpaceBeforeParens: ControlStatements
-SpaceInEmptyParentheses: false
 SpaceBeforeCpp11BracedList: true
-SpacesBeforeTrailingComments: 1
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: '1'
+SpacesInAngles: false
 SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        c++11
-TabWidth:        8
-UseTab:          Never
-...
-
+Standard: Cpp11
+TabWidth: '4'
+UseTab: Never

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -67,6 +67,7 @@ jobs:
 
   check-commit-message:
     name: Check Commit Message
+    needs: check-for-duplicates
     # Only run for pull-requests.
     if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'ic-') }}
     runs-on: ubuntu-22.04
@@ -77,7 +78,7 @@ jobs:
         uses: gsactions/commit-message-checker@v2
         if: always()
         with:
-          pattern: ^((Fix|HotFix|Part|Issue|Ticket)\s([a-zA-Z0-9_-]+/)?[a-zA-Z0-9_-]*\#[0-9]+[,:]\s.+|Merge\spull\srequest\s\#[0-9]+\s.+|IC:\s.+)
+          pattern: '^((Fix|HotFix|Part|Issue|Ticket)\s(nasa/)?[a-zA-Z]*\#[0-9]+[,:]\s[a-zA-Z0-9]+|Merge\spull\srequest\s\#[0-9]+\s[a-zA-Z0-9]+|IC:\s[a-zA-Z0-9]+)'
           error: 'You need at least one "Fix|HotFix|Part|Issue|Ticket #<issue number><,|:> <short description>" line in the commit message.'
           excludeDescription: 'true'
           excludeTitle: 'true'


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #965 

**Testing performed**
Before changes on OSAL: https://github.com/nasa/osal/actions/runs/24360917195/job/71140758390
After: https://github.com/arielswalker/osal/actions/runs/24368005007/job/71164701311

**Expected behavior changes**
The dev branch format check workflow should use the same .clang-format file as the internal repositories. There may still be failing workflows where we need to update the code so there are no style differences. 

**System(s) tested on**
GitHub Actions

**Additional context**
I also updated the format check workflow because it was missing `needs:` for the commit message step. I also updated that step to allow commit messages to reference issues in outside repositories as done in the internal workflow. I did not add anything new when compared to the internal workflow, except the .clang-format file did not work with `...` added to the end of that file which was removed. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.
