### PR TITLE
Docs: Fix broken links, typos, and incorrect git instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ If applicable, add references to the software.
 **System observed on:**
  - Hardware
  - OS: [e.g. Linux 4.4]
- - Versions [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps]
+ - Versions [e.g. cFE 7.0.0, OSAL 4.2, PSP 1.3 for mcp750, any related apps]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@ A clear and concise description of how this contribution will change behavior an
 **System(s) tested on**
  - Hardware: [e.g. PC, SP0, MCP750]
  - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
- - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]
+ - Versions: [e.g. cFE 7.0.0, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]
 
 **Additional context**
 Add any other context about the contribution here.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,16 +24,8 @@ This action builds, tests, and runs the cFS bundle omitting deprecated code.
 
 Build, Test, and Run [OMIT_DEPRECATED=true] runs for every push and every pull request on all branches of cFS in Github Actions. For more information on the OMIT_DEPRECATED flag, see [global_build_options.cmake](https://github.com/nasa/cFE/blob/063b4d8a9c4a7e822af5f3e4017599159b985bb0/cmake/sample_defs/global_build_options.cmake). 
 
-## Build and Test in RTEMS [OMIT_DEPRECATED=true]
-[![Build and Test rtems 4.11 [OMIT_DEPRECATED=true]](https://github.com/nasa/cFS/actions/workflows/build-cfs-rtems4.11.yml/badge.svg)](https://github.com/nasa/cFS/actions/workflows/build-cfs-rtems4.11.yml)
-[![Build and Test rtems 5 [OMIT_DEPRECATED=true]](https://github.com/nasa/cFS/actions/workflows/build-cfs-rtems5.yml/badge.svg)](https://github.com/nasa/cFS/actions/workflows/build-cfs-rtems5.yml)
-
-This action builds and tests the cFS bundle omitting deprecated code in both RTEMS 4.11 and RTEMS 5.
-
-Build and Test in RTEMS 4.11 and 5 runs for every push and every pull request on all branches of cFS in Github Actions.
-
 ## CodeQL Analysis
-[![CodeQL Analysis](https://github.com/nasa/cfs/actions/workflows/codeql-build.yml/badge.svg)](https://github.com/nasa/cfs/actions/workflows/codeql-build.yml)
+[![CodeQL Analysis](https://github.com/nasa/cfs/actions/workflows/codeql-build.yml/badge.svg)](https://github.com/nasa/cfs/actions/workflows/codeql-analysis.yml)
 
 This action runs GitHub's static analysis engine, CodeQL, against our repository's source code to find security vulnerabilities. It then automatically uploads the results to GitHub so they can be displayed in the repository's code scanning alerts found under the security tab. CodeQL runs an extensible set of [queries](https://github.com/github/codeql), which have been developed by the community and the [GitHub Security Lab](https://securitylab.github.com/) to find common vulnerabilities in your code.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -22,7 +22,11 @@ Build, Test, and Run runs for every push and every pull request on all branches 
 
 This action builds, tests, and runs the cFS bundle omitting deprecated code.
 
-Build, Test, and Run [OMIT_DEPRECATED=true] runs for every push and every pull request on all branches of cFS in Github Actions. For more information on the OMIT_DEPRECATED flag, see [global_build_options.cmake](https://github.com/nasa/cFE/blob/063b4d8a9c4a7e822af5f3e4017599159b985bb0/cmake/sample_defs/global_build_options.cmake). 
+Build, Test, and Run [OMIT_DEPRECATED=true] runs for every push and every pull request on all branches of cFS in Github Actions. For more information on the OMIT_DEPRECATED flag, see [global_build_options.cmake](https://github.com/nasa/cFE/blob/063b4d8a9c4a7e822af5f3e4017599159b985bb0/cmake/sample_defs/global_build_options.cmake).
+
+## Build and Test in RTEMS [OMIT_DEPRECATED=true]
+[![Build and Test rtems 4.11 [OMIT_DEPRECATED=true]](https://github.com/nasa/cFS/actions/workflows/build-cfs-rtems4.11.yml/badge.svg)](https://github.com/nasa/cFS/actions/workflows/build-cfs-rtems4.11.yml)
+[![Build and Test rtems 5 [OMIT_DEPRECATED=true]](https://github.com/nasa/cFS/actions/workflows/build-cfs-rtems5.yml/badge.svg)](https://github.com/nasa/cFS/actions/workflows/build-cfs-rtems5.yml)
 
 ## CodeQL Analysis
 [![CodeQL Analysis](https://github.com/nasa/cfs/actions/workflows/codeql-build.yml/badge.svg)](https://github.com/nasa/cfs/actions/workflows/codeql-analysis.yml)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ Ready to Add Your Code? Follow GitHub's fork-branch-pull request pattern.
 
 3. Create a new branch in your fork to work on your fix. We recommend naming your branch `fix-ISSUE_NUMBER-<FIX_SUMMARY>`.
 
-3. Add commits to your branch. For information on commit messages, review [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/) and our [git commit guidelines](#GitCommitGuidelines).
+4. Add commits to your branch. For information on commit messages, review [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/) and our [git commit guidelines](#GitCommitGuidelines).
 
 #### <a name='CreatingaPullRequest'></a>Creating a Pull Request
 
@@ -290,7 +290,7 @@ git checkout main && git pull
 ```
 2. Checkout your feature branch:
 ```sh
-git merge feature_branch
+git checkout feature_branch
 ```
 3. Use rebase to open the vi or other editor that lists the commits:
 ```sh
@@ -349,7 +349,7 @@ git push --force
 
 ###### Replace Branch
 
-This method had no chances of inadvertently overwriting other stuff.
+This method has no chances of inadvertently overwriting other stuff.
 
 1. Make a new branch with a new name at the current main:
 ```sh

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The cFS Framework is a core subset of cFS, with an extensive ecosystem of applic
 
 ## Distributions
 
-This is the open-source version of cFS, released under an Apache 2.0 license. The open source cFS is limited to the framework and common apps, libraries, and tools, which includes and is limited to: cFE, OSAL, PSP, Command Ingest (Lab), Telemetry Output (Lab), Scheduler (Lab), Sample App, Sample Lib, Data Storage, File Manager, HouseKeeping, Health and Safety, Memory Dwell, CFDP File Transfer, CheckSum, Limit Checker, Memory Manager, Stored Command, cFS Ground System, elf2cfetbl, and tblCRCTool. Changes to the open repositories are limited to bug fixes and minor enhancements to those components.
+This is the open-source version of cFS, released under an Apache 2.0 license. The open source cFS is limited to the framework and common apps, libraries, and tools, which includes and is limited to: cFE, OSAL, PSP, Command Ingest (Lab), Telemetry Output (Lab), Scheduler (Lab), Sample App, Sample Lib, Skeleton App, Data Storage, File Manager, HouseKeeping, Health and Safety, Memory Dwell, CFDP File Transfer, CheckSum, Limit Checker, Memory Manager, Stored Command, cFS Ground System, elf2cfetbl, and tblCRCTool. Changes to the open repositories are limited to bug fixes and minor enhancements to those components.
 
 A Government-use (Distro C) version of cFS with features for a full flight mission is available through a Software User Agreement. For more information about government version features or to explore partnerships, please [contact the cFS team](<mailto:cfs-program@lists.nasa.gov>).
 
@@ -42,7 +42,7 @@ More information is available on the [cFS Website](<https://cfs.gsfc.nasa.gov>).
 - [OSAL User's Guide](<https://github.com/nasa/cFS/blob/gh-pages/osal-apiguide.pdf>)
 - [cFE App Developer's Guide](<https://github.com/nasa/cFE/blob/main/docs/cFE%20Application%20Developers%20Guide.md>)
 - [Training documentation](<https://ntrs.nasa.gov/citations/20240000217>)
-- [cFS Overview](<https://cfs.gsfc.nasa.gov/cFS-OviewBGSlideDeck-ExportControl-Final.pdf>)
+- [cFS Overview](<https://cfs.gsfc.nasa.gov>)
 
 ## Release Notes
 
@@ -101,7 +101,7 @@ Copy in the default makefile and definitions:
 
 ## Build and Run
 
-The cFS Framework including sample applications will build and run on the pc-linux platform support package (should run on most Linux distributions), via the steps described in [the cFE cmake readme](<https://github.com/nasa/cFE/tree/master/cmake/README.md>).  Quick-start is below:
+The cFS Framework including sample applications will build and run on the pc-linux platform support package (should run on most Linux distributions), via the steps described in [the cFE cmake readme](<https://github.com/nasa/cFE/tree/main/cmake/README.md>).  Quick-start is below:
 
 To prep, compile, and run on the host (from cFS directory above) as a normal user (best effort message queue depth and task priorities):
 
@@ -164,19 +164,19 @@ See the [cFE Application Developer's Guide](https://github.com/nasa/cFE/blob/mai
   - Skeleton App: A bare-bones application to which you can add your business logic at <https://github.com/nasa/skeleton_app>
 - Other Interfaces
   - cFS COSMOS Plugin: COSMOS plugin for testing cFS <https://github.com/nasa/cfs-cosmos-plugin>
-  - cFS Command Line Tools: Simple command line utilities to send a command or view telemery on the console <https://github.com/nasa/cfs-commandline-tools>
+  - cFS Command Line Tools: Simple command line utilities to send a command or view telemetry on the console <https://github.com/nasa/cfs-commandline-tools>
   - SIL: Simulink Interface Layer at <https://github.com/nasa/SIL>
   - ECI: External Code Interface at <https://github.com/nasa/ECI>
   - SBN-Client: External code interface to SBN at <https://github.com/nasa/SBN-Client>
 - Other Libraries
   - BPLib: DTN Bundle Protocol library at <https://github.com/nasa/bplib>
   - cFS_IO_LIB: IO library at <https://github.com/nasa/CFS_IO_LIB>
-  - cFS_LIB: at <https://github.com/nasa/cfs_lib>
+  - cFS_LIB: cFS general purpose utility library at <https://github.com/nasa/cfs_lib>
   - EdsLib: CCSDS SOIS Electronic Data Sheet Tool and Library at <https://github.com/nasa/EdsLib>
   - fs_lib: File services library at <https://github.com/nasa/fs_lib>
 - Other Tools
   - CTF: cFS Test Framework at <https://github.com/nasa/CTF>
   - CCDD: Command and Data Dictionary Tool at <https://github.com/nasa/CCDD>
   - Perfutils-java: Java based performance analyzer for cFS at <https://github.com/nasa/perfutils-java>
-  - gen_sch_tbl: Tool to generated SCH app tables at <https://github.com/nasa/gen_sch_tbl>
+  - gen_sch_tbl: Tool to generate SCH app tables at <https://github.com/nasa/gen_sch_tbl>
   - CryptoLib: Software-only CCSDS Space Data Link Security Protocol - Extended Procedures (SDLS-EP) at <https://github.com/nasa/CryptoLib>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ Testing is an important aspect our team values to improve the cFS bundle. Severa
 
 The [cFS CodeQL GitHub Actions workflow](https://github.com/nasa/cFS/actions/workflows/codeql-analysis.yml) is available to the public. To review the results, fork the cFS repository and run the CodeQL workflow.
 
-CodeQL is ran for every push and pull-request on all branches of cFS in GitHub Actions.
+CodeQL is run for every push and pull-request on all branches of cFS in GitHub Actions.
 
 For the CodeQL GitHub Actions setup, visit https://github.com/github/codeql-action.
 
@@ -28,7 +28,7 @@ For the CodeQL GitHub Actions setup, visit https://github.com/github/codeql-acti
 
 The [cFS Cppcheck GitHub Actions workflow and results](https://github.com/nasa/cFS/actions/workflows/static-analysis.yml) are available to the public. To view the results, select a workflow and download the artifacts.
 
-Cppcheck is ran for every push on the main branch and every pull request on all branches of cFS in Github Actions.
+Cppcheck is run for every push on the main branch and every pull request on all branches of cFS in Github Actions.
 
 For more information about Cppcheck, visit http://cppcheck.sourceforge.net/.
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fix documentation errors across multiple files in the cFS bundle: broken links, typos, incorrect git instructions, stale references, and missing content.

**Changes:**
- **README.md**: Fix broken cFS Overview PDF link, `master`→`main` branch ref, add missing cFS_LIB description, add Skeleton App to distributions list
- **CONTRIBUTING.md**: Fix `git merge`→`git checkout` in squash instructions, fix duplicate step numbering (3→4), fix "had"→"has" grammar
- **.github/workflows/README.md**: Fix `codeql-build.yml`→`codeql-analysis.yml` badge
- **.github/ISSUE_TEMPLATE/bug_report.md**: Update outdated version examples (cFE 6.6→7.0.0)
- **.github/pull_request_template.md**: Update outdated version examples (cFE 6.6→7.0.0)
- **SECURITY.md**: Fix "is ran"→"is run" grammar (×2)

**Testing performed**
1. Verified all updated links resolve correctly
2. Reviewed all changes for accuracy against live GitHub repos

**Expected behavior changes**
No impact to behavior  documentation only changes.

**System(s) tested on**
- N/A (documentation only)

**Additional context**
None.

**NOTE:-**
CLA already signed and sent for previous PR(s).