### PR TITLE
Fix #1005, pass through dependency in codeQL workflow

### DIFF
--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -46,6 +46,13 @@ on:
         default: 'false'
         required: false
 
+      dependency:
+        description: Additional module/library that this app depends on
+        type: string
+        required: false
+        default: ''
+
+
 # Force bash to apply pipefail option so pipeline failures aren't masked
 defaults:
   run:


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Pass the "dependency" input value through to the setup app action

Fixes #1005

**Testing performed**
Run codeQL

**Expected behavior changes**
Dependency issue resolved

**Additional context**
This is needed for apps that depend on other components (e.g. sample_app depends on sample_lib) in order for them to build properly.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
