### PR TITLE
Part #1029, harden workflow run expressions

### DIFF
--- a/.github/workflows/build-cfs-multitarget.yml
+++ b/.github/workflows/build-cfs-multitarget.yml
@@ -70,10 +70,14 @@ jobs:
           token: ${{ secrets.GH_PAT || github.token }}
 
       - name: Configure CFS
-        run: make ${{ inputs.config-name }}.prep
+        env:
+          INPUT_CONFIG_NAME: ${{ inputs.config-name }}
+        run: make "${INPUT_CONFIG_NAME}.prep"
 
       - name: Build CFS
-        run: make ${{ inputs.config-name }}.install
+        env:
+          INPUT_CONFIG_NAME: ${{ inputs.config-name }}
+        run: make "${INPUT_CONFIG_NAME}.install"
 
       - name: Configure xz compression
         if: inputs.compression-type == 'xz'
@@ -88,8 +92,10 @@ jobs:
           echo "COMPRESSOR=gzip -c" >> $GITHUB_ENV
 
       - name: Archive binaries
+        env:
+          INPUT_CONFIG_NAME: ${{ inputs.config-name }}
         run: |
-          cd $GITHUB_WORKSPACE/build-${{ inputs.config-name }}/exe
+          cd "$GITHUB_WORKSPACE/build-${INPUT_CONFIG_NAME}/exe"
           find -maxdepth 1 -mindepth 1 -type d | while read dir
           do
             inst=$(basename ${dir})
@@ -97,11 +103,15 @@ jobs:
           done
 
       - name: Build target images
-        run: make IMAGE_TYPE=ext4 ${{ inputs.config-name }}.image
+        env:
+          INPUT_CONFIG_NAME: ${{ inputs.config-name }}
+        run: make IMAGE_TYPE=ext4 "${INPUT_CONFIG_NAME}.image"
 
       - name: Archive target images
+        env:
+          INPUT_CONFIG_NAME: ${{ inputs.config-name }}
         run: |
-          if cd $GITHUB_WORKSPACE/build-${{ inputs.config-name }}/deploy
+          if cd "$GITHUB_WORKSPACE/build-${INPUT_CONFIG_NAME}/deploy"
           then
             find -maxdepth 1 -mindepth 1 -type d | while read dir
             do
@@ -118,8 +128,12 @@ jobs:
 
       - name: Run Local Tests
         if: ${{ inputs.run-local-tests }}
-        run: make ${{ inputs.config-name }}.runtest
+        env:
+          INPUT_CONFIG_NAME: ${{ inputs.config-name }}
+        run: make "${INPUT_CONFIG_NAME}.runtest"
 
       - name: Generate Coverage Report
         if: ${{ inputs.check-coverage }}
-        run: make ${{ inputs.config-name }}.lcov
+        env:
+          INPUT_CONFIG_NAME: ${{ inputs.config-name }}
+        run: make "${INPUT_CONFIG_NAME}.lcov"

--- a/.github/workflows/build-doc-reusable.yml
+++ b/.github/workflows/build-doc-reusable.yml
@@ -89,9 +89,11 @@ jobs:
         run: make -C build osal_public_api_headerlist
 
       - name: Build Document
+        env:
+          MATRIX_TARGET: ${{ matrix.target }}
         run: |
-          make -C build ${{ matrix.target }} 2>&1 > ${{ matrix.target }}_stdout.txt | tee ${{ matrix.target }}_stderr.txt
-          mv build/docs/${{ matrix.target }}/${{ matrix.target }}-warnings.log .
+          make -C build "$MATRIX_TARGET" 2>&1 > "${MATRIX_TARGET}_stdout.txt" | tee "${MATRIX_TARGET}_stderr.txt"
+          mv "build/docs/${MATRIX_TARGET}/${MATRIX_TARGET}-warnings.log" .
 
       - name: Archive Document Build Logs
         uses: actions/upload-artifact@v7
@@ -103,31 +105,37 @@ jobs:
             ${{ matrix.target }}-warnings.log
 
       - name: Check For Document Build Errors
+        env:
+          MATRIX_TARGET: ${{ matrix.target }}
         run: |
-          if [[ -s ${{ matrix.target }}_stderr.txt ]]; then
-            cat ${{ matrix.target }}_stderr.txt
+          if [[ -s "${MATRIX_TARGET}_stderr.txt" ]]; then
+            cat "${MATRIX_TARGET}_stderr.txt"
             exit 1
           fi
 
       - name: Check For Document Warnings
+        env:
+          MATRIX_TARGET: ${{ matrix.target }}
         run: |
-          if [[ -s ${{ matrix.target }}-warnings.log ]]; then
-            cat ${{ matrix.target }}-warnings.log
+          if [[ -s "${MATRIX_TARGET}-warnings.log" ]]; then
+            cat "${MATRIX_TARGET}-warnings.log"
             exit 1
           fi
 
       - name: Generate PDF
         if: ${{ inputs.buildpdf == true }}
+        env:
+          MATRIX_TARGET: ${{ matrix.target }}
         run: |
-          if ! make LATEX_CMD="pdflatex -file-line-error -halt-on-error" -C ./build/docs/${{ matrix.target }}/latex > pdflatex.log; then
+          if ! make LATEX_CMD="pdflatex -file-line-error -halt-on-error" -C "./build/docs/${MATRIX_TARGET}/latex" > pdflatex.log; then
             echo "Errors reported, tail of latex output follows"
             tail -100 pdflatex.log
             exit -1
           fi
           mkdir -p deploy
-          mv ./build/docs/${{ matrix.target }}/latex/refman.pdf ./deploy/${{ matrix.target }}.pdf
+          mv "./build/docs/${MATRIX_TARGET}/latex/refman.pdf" "./deploy/${MATRIX_TARGET}.pdf"
           # Could add pandoc and convert to github markdown
-          # pandoc ${{ matrix.target }}.pdf -t gfm
+          # pandoc ${MATRIX_TARGET}.pdf -t gfm
 
       - name: Archive PDF
         if: ${{ inputs.buildpdf == true }}

--- a/.github/workflows/build-doc-reusable.yml
+++ b/.github/workflows/build-doc-reusable.yml
@@ -89,8 +89,10 @@ jobs:
         run: make -C build osal_public_api_headerlist
 
       - name: Build Document
+        env:
+          MATRIX_TARGET: ${{ matrix.target }}
         run: |
-          make -C build ${{ matrix.target }} 2>&1 > ${{ matrix.target }}_stdout.txt | tee ${{ matrix.target }}_stderr.txt
+          make -C build "$MATRIX_TARGET" 2>&1 > "${MATRIX_TARGET}_stdout.txt" | tee "${MATRIX_TARGET}_stderr.txt"
 
       - name: Filter warnings
         env:
@@ -113,31 +115,37 @@ jobs:
             ${{ matrix.target }}-warnings.log
 
       - name: Check For Document Build Errors
+        env:
+          MATRIX_TARGET: ${{ matrix.target }}
         run: |
-          if [[ -s ${{ matrix.target }}_stderr.txt ]]; then
-            cat ${{ matrix.target }}_stderr.txt
+          if [[ -s "${MATRIX_TARGET}_stderr.txt" ]]; then
+            cat "${MATRIX_TARGET}_stderr.txt"
             exit 1
           fi
 
       - name: Check For Document Warnings
+        env:
+          MATRIX_TARGET: ${{ matrix.target }}
         run: |
-          if [[ -s ${{ matrix.target }}-warnings.log ]]; then
-            cat ${{ matrix.target }}-warnings.log
+          if [[ -s "${MATRIX_TARGET}-warnings.log" ]]; then
+            cat "${MATRIX_TARGET}-warnings.log"
             exit 1
           fi
 
       - name: Generate PDF
         if: ${{ inputs.buildpdf == true }}
+        env:
+          MATRIX_TARGET: ${{ matrix.target }}
         run: |
-          if ! make LATEX_CMD="pdflatex -file-line-error -halt-on-error" -C ./build/docs/${{ matrix.target }}/latex > pdflatex.log; then
+          if ! make LATEX_CMD="pdflatex -file-line-error -halt-on-error" -C "./build/docs/${MATRIX_TARGET}/latex" > pdflatex.log; then
             echo "Errors reported, tail of latex output follows"
             tail -100 pdflatex.log
             exit -1
           fi
           mkdir -p deploy
-          mv ./build/docs/${{ matrix.target }}/latex/refman.pdf ./deploy/${{ matrix.target }}.pdf
+          mv "./build/docs/${MATRIX_TARGET}/latex/refman.pdf" "./deploy/${MATRIX_TARGET}.pdf"
           # Could add pandoc and convert to github markdown
-          # pandoc ${{ matrix.target }}.pdf -t gfm
+          # pandoc ${MATRIX_TARGET}.pdf -t gfm
 
       - name: Archive PDF
         if: ${{ inputs.buildpdf == true }}

--- a/.github/workflows/build-run-app-reusable.yml
+++ b/.github/workflows/build-run-app-reusable.yml
@@ -69,11 +69,13 @@ jobs:
           enable-eds: ${{ inputs.enable-eds }}
 
       - name: Set up start string for verification
+        env:
+          INPUT_STARTUP_STRING: ${{ inputs.startup-string }}
         run: |
-          if [[ "${{ inputs.startup-string }}" == '' ]]; then
+          if [[ "${INPUT_STARTUP_STRING}" == '' ]]; then
             echo "START_STRING=$APP_UPPER Initialized." >> $GITHUB_ENV
           else
-            echo "START_STRING=${{ inputs.startup-string }}" >> $GITHUB_ENV
+            echo "START_STRING=${INPUT_STARTUP_STRING}" >> $GITHUB_ENV
           fi
 
       - name: Create startup script generator
@@ -98,7 +100,9 @@ jobs:
         run: cmake -DEXCLUDE=$APP_LOWER -P generate_startup_script.cmake 2>&1 | tee -a ${GITHUB_WORKSPACE}/generated_cfe_es_startup.scr
 
       - name: Add subject app to startup script
-        run: echo "CFE_APP, $APP_LOWER, ${APP_UPPER}_${{ inputs.app-entrypoint-suffix }}, $APP_UPPER, 80, 16384, 0x0, 0;" >> ${GITHUB_WORKSPACE}/generated_cfe_es_startup.scr
+        env:
+          INPUT_APP_ENTRYPOINT_SUFFIX: ${{ inputs.app-entrypoint-suffix }}
+        run: echo "CFE_APP, $APP_LOWER, ${APP_UPPER}_${INPUT_APP_ENTRYPOINT_SUFFIX}, $APP_UPPER, 80, 16384, 0x0, 0;" >> ${GITHUB_WORKSPACE}/generated_cfe_es_startup.scr
 
       - name: Check startup script
         if: always()
@@ -145,13 +149,16 @@ jobs:
         run: ls -lR .
 
       - name: Unpack artifacts
+        env:
+          INPUT_APP_NAME: ${{ inputs.app-name }}
+          MATRIX_VARIANT: ${{ matrix.variant }}
         run: |
           for i in cpu1 host lib
           do
-            tarball="$GITHUB_WORKSPACE/${{ inputs.app-name }}-bin${{ env.BUILD_TAG }}/$i-bin.tar.xz"
+            tarball="$GITHUB_WORKSPACE/${INPUT_APP_NAME}-bin${BUILD_TAG}/$i-bin.tar.xz"
             if [ -e "$tarball" ]; then
-              mkdir -p "${{ matrix.variant }}/$i"
-              tar Jxv -C "${{ matrix.variant }}/$i" -f "$tarball"
+              mkdir -p "${MATRIX_VARIANT}/$i"
+              tar Jxv -C "${MATRIX_VARIANT}/$i" -f "$tarball"
             fi
           done
 
@@ -178,8 +185,10 @@ jobs:
       - name: Get IP address of host container
         shell: bash
         id: query-local-ip-addr
+        env:
+          STEP_CHECK_CPU1_IP_ADDR: ${{ steps.check-cpu1.outputs.ip-addr }}
         run: |
-          cont_ip=${{ steps.check-cpu1.outputs.ip-addr }}
+          cont_ip="${STEP_CHECK_CPU1_IP_ADDR}"
           for ip in $(hostname -I)
           do
             first_ip=${first_ip:-${ip}}
@@ -196,33 +205,45 @@ jobs:
       - name: Execute Test Script (EDS)
         if: ${{ matrix.variant == 'eds' && steps.check-cpu1.outputs.ip-addr != '' }}
         working-directory: ${{ matrix.variant }}/host
+        env:
+          MATRIX_VARIANT: ${{ matrix.variant }}
+          STEP_CHECK_CPU1_IP_ADDR: ${{ steps.check-cpu1.outputs.ip-addr }}
+          STEP_QUERY_LOCAL_IP_ADDR_ADDR: ${{ steps.query-local-ip-addr.outputs.addr }}
+          INPUT_APP_NAME: ${{ inputs.app-name }}
         run: |
-          export LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/${{ matrix.variant }}/lib
-          export PYTHONPATH=${GITHUB_WORKSPACE}/${{ matrix.variant }}/lib/python
+          export LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/${MATRIX_VARIANT}/lib
+          export PYTHONPATH=${GITHUB_WORKSPACE}/${MATRIX_VARIANT}/lib/python
           ./runtest.py --instance-name 'cpu1' \
-            --remote-addr '${{ steps.check-cpu1.outputs.ip-addr }}:1234' \
-            --local-addr '${{ steps.query-local-ip-addr.outputs.addr }}:2234' \
+            --remote-addr "${STEP_CHECK_CPU1_IP_ADDR}:1234" \
+            --local-addr "${STEP_QUERY_LOCAL_IP_ADDR_ADDR}:2234" \
             --mission-name 'githubactions' \
-            '${{ inputs.app-name }}' 'test_aliveness'
+            "${INPUT_APP_NAME}" 'test_aliveness'
           sleep 2
 
       - name: Shut down CFE (STD)
         if: ${{ matrix.variant == 'std' && steps.check-cpu1.outputs.ip-addr != '' }}
         working-directory: ${{ matrix.variant }}/host
+        env:
+          STEP_CHECK_CPU1_IP_ADDR: ${{ steps.check-cpu1.outputs.ip-addr }}
         run: |
-          ./cmd_send -v --host=${{ steps.check-cpu1.outputs.ip-addr }} --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
+          ./cmd_send -v --host="${STEP_CHECK_CPU1_IP_ADDR}" --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
           sleep 2
 
       - name: Shut down CFE (EDS)
         if: ${{ matrix.variant == 'eds' && steps.check-cpu1.outputs.ip-addr != '' }}
         working-directory: ${{ matrix.variant }}/host
+        env:
+          STEP_CHECK_CPU1_IP_ADDR: ${{ steps.check-cpu1.outputs.ip-addr }}
         run: |
-          ./cmd_send -v --host=${{ steps.check-cpu1.outputs.ip-addr }} --endian=EDS --pktid=CFE_ES/Application/CMD --cmdcode=RestartCmd RestartType=2
+          ./cmd_send -v --host="${STEP_CHECK_CPU1_IP_ADDR}" --endian=EDS --pktid=CFE_ES/Application/CMD --cmdcode=RestartCmd RestartType=2
           sleep 2
 
       - name: Capture Logs
         if: ${{ always() && steps.start-cpu1.outputs.container-id != '' }}
-        run: docker logs ${{ steps.start-cpu1.outputs.container-id }} > ${{ matrix.variant }}/cFS_startup_cpu1.txt
+        env:
+          STEP_START_CPU1_CONTAINER_ID: ${{ steps.start-cpu1.outputs.container-id }}
+          MATRIX_VARIANT: ${{ matrix.variant }}
+        run: docker logs "$STEP_START_CPU1_CONTAINER_ID" > "${MATRIX_VARIANT}/cFS_startup_cpu1.txt"
 
       - name: Stop CPU1 Container
         #if: ${{ always() && steps.start-cpu1.outputs.container-id != '' }}
@@ -238,21 +259,25 @@ jobs:
           path: ${{ matrix.variant }}/cFS_startup_cpu1.txt
 
       - name: Confirm startup string
+        env:
+          MATRIX_VARIANT: ${{ matrix.variant }}
         run: |
-          if [[ -z $(grep "$START_STRING" ${{ matrix.variant }}/cFS_startup_cpu1.txt) ]]; then
+          if [[ -z $(grep "$START_STRING" "${MATRIX_VARIANT}/cFS_startup_cpu1.txt") ]]; then
             echo "Startup verification string not found in log: $START_STRING"
             echo ""
             echo "Possible related event messages:"
-            grep "/$APP_UPPER " ${{ matrix.variant }}/cFS_startup_cpu1.txt
+            grep "/$APP_UPPER " "${MATRIX_VARIANT}/cFS_startup_cpu1.txt"
             exit -1
           fi
 
       - name: Check for cFS Warnings
         if: success() || failure()
+        env:
+          MATRIX_VARIANT: ${{ matrix.variant }}
         run: |
-          if [[ -n $(grep -i "warn\|err\|fail" ${{ matrix.variant }}/cFS_startup_cpu1.txt) ]]; then
+          if [[ -n $(grep -i "warn\|err\|fail" "${MATRIX_VARIANT}/cFS_startup_cpu1.txt") ]]; then
                   echo "cFS startup warn|err|fail:"
                   echo ""
-                  grep -i 'warn\|err\|fail' ${{ matrix.variant }}/cFS_startup_cpu1.txt
+                  grep -i 'warn\|err\|fail' "${MATRIX_VARIANT}/cFS_startup_cpu1.txt"
                   exit -1
           fi

--- a/.github/workflows/build-run-app-reusable.yml
+++ b/.github/workflows/build-run-app-reusable.yml
@@ -69,11 +69,13 @@ jobs:
           enable-eds: ${{ inputs.enable-eds }}
 
       - name: Set up start string for verification
+        env:
+          INPUT_STARTUP_STRING: ${{ inputs.startup-string }}
         run: |
-          if [[ "${{ inputs.startup-string }}" == '' ]]; then
+          if [[ "${INPUT_STARTUP_STRING}" == '' ]]; then
             echo "START_STRING=$APP_UPPER Initialized." >> $GITHUB_ENV
           else
-            echo "START_STRING=${{ inputs.startup-string }}" >> $GITHUB_ENV
+            echo "START_STRING=${INPUT_STARTUP_STRING}" >> $GITHUB_ENV
           fi
 
       - name: Create startup script generator
@@ -98,7 +100,9 @@ jobs:
         run: cmake -DEXCLUDE=$APP_LOWER -P generate_startup_script.cmake 2>&1 | tee -a ${GITHUB_WORKSPACE}/generated_cfe_es_startup.scr
 
       - name: Add subject app to startup script
-        run: echo "CFE_APP, $APP_LOWER, ${APP_UPPER}_${{ inputs.app-entrypoint-suffix }}, $APP_UPPER, 80, 16384, 0x0, 0;" >> ${GITHUB_WORKSPACE}/generated_cfe_es_startup.scr
+        env:
+          INPUT_APP_ENTRYPOINT_SUFFIX: ${{ inputs.app-entrypoint-suffix }}
+        run: echo "CFE_APP, $APP_LOWER, ${APP_UPPER}_${INPUT_APP_ENTRYPOINT_SUFFIX}, $APP_UPPER, 80, 16384, 0x0, 0;" >> ${GITHUB_WORKSPACE}/generated_cfe_es_startup.scr
 
       - name: Check startup script
         if: always()
@@ -132,8 +136,10 @@ jobs:
 
     steps:
       - name: Check build tag
+        env:
+          MATRIX_BUILD_TAG: ${{ fromJSON(inputs.enable-eds) && format('-{0}', matrix.variant) || '' }}
         run:
-          echo "BUILD_TAG=${{ fromJSON(inputs.enable-eds) && format('-{0}', matrix.variant) || '' }}" >> $GITHUB_ENV
+          echo "BUILD_TAG=$MATRIX_BUILD_TAG" >> "$GITHUB_ENV"
 
       - name: Download artifact
         uses: actions/download-artifact@v8
@@ -145,13 +151,16 @@ jobs:
         run: ls -lR .
 
       - name: Unpack artifacts
+        env:
+          INPUT_APP_NAME: ${{ inputs.app-name }}
+          MATRIX_VARIANT: ${{ matrix.variant }}
         run: |
           for i in cpu1 host lib
           do
-            tarball="$GITHUB_WORKSPACE/${{ inputs.app-name }}-bin${{ env.BUILD_TAG }}/$i-bin.tar.xz"
+            tarball="$GITHUB_WORKSPACE/${INPUT_APP_NAME}-bin${BUILD_TAG}/$i-bin.tar.xz"
             if [ -e "$tarball" ]; then
-              mkdir -p "${{ matrix.variant }}/$i"
-              tar Jxv -C "${{ matrix.variant }}/$i" -f "$tarball"
+              mkdir -p "${MATRIX_VARIANT}/$i"
+              tar Jxv -C "${MATRIX_VARIANT}/$i" -f "$tarball"
             fi
           done
 
@@ -178,8 +187,10 @@ jobs:
       - name: Get IP address of host container
         shell: bash
         id: query-local-ip-addr
+        env:
+          STEP_CHECK_CPU1_IP_ADDR: ${{ steps.check-cpu1.outputs.ip-addr }}
         run: |
-          cont_ip=${{ steps.check-cpu1.outputs.ip-addr }}
+          cont_ip="${STEP_CHECK_CPU1_IP_ADDR}"
           for ip in $(hostname -I)
           do
             first_ip=${first_ip:-${ip}}
@@ -196,33 +207,45 @@ jobs:
       - name: Execute Test Script (EDS)
         if: ${{ matrix.variant == 'eds' && steps.check-cpu1.outputs.ip-addr != '' }}
         working-directory: ${{ matrix.variant }}/host
+        env:
+          MATRIX_VARIANT: ${{ matrix.variant }}
+          STEP_CHECK_CPU1_IP_ADDR: ${{ steps.check-cpu1.outputs.ip-addr }}
+          STEP_QUERY_LOCAL_IP_ADDR_ADDR: ${{ steps.query-local-ip-addr.outputs.addr }}
+          INPUT_APP_NAME: ${{ inputs.app-name }}
         run: |
-          export LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/${{ matrix.variant }}/lib
-          export PYTHONPATH=${GITHUB_WORKSPACE}/${{ matrix.variant }}/lib/python
+          export LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/${MATRIX_VARIANT}/lib
+          export PYTHONPATH=${GITHUB_WORKSPACE}/${MATRIX_VARIANT}/lib/python
           ./runtest.py --instance-name 'cpu1' \
-            --remote-addr '${{ steps.check-cpu1.outputs.ip-addr }}:1234' \
-            --local-addr '${{ steps.query-local-ip-addr.outputs.addr }}:2234' \
+            --remote-addr "${STEP_CHECK_CPU1_IP_ADDR}:1234" \
+            --local-addr "${STEP_QUERY_LOCAL_IP_ADDR_ADDR}:2234" \
             --mission-name 'githubactions' \
-            '${{ inputs.app-name }}' 'test_aliveness'
+            "${INPUT_APP_NAME}" 'test_aliveness'
           sleep 2
 
       - name: Shut down CFE (STD)
         if: ${{ matrix.variant == 'std' && steps.check-cpu1.outputs.ip-addr != '' }}
         working-directory: ${{ matrix.variant }}/host
+        env:
+          STEP_CHECK_CPU1_IP_ADDR: ${{ steps.check-cpu1.outputs.ip-addr }}
         run: |
-          ./cmd_send -v --host=${{ steps.check-cpu1.outputs.ip-addr }} --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
+          ./cmd_send -v --host="${STEP_CHECK_CPU1_IP_ADDR}" --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
           sleep 2
 
       - name: Shut down CFE (EDS)
         if: ${{ matrix.variant == 'eds' && steps.check-cpu1.outputs.ip-addr != '' }}
         working-directory: ${{ matrix.variant }}/host
+        env:
+          STEP_CHECK_CPU1_IP_ADDR: ${{ steps.check-cpu1.outputs.ip-addr }}
         run: |
-          ./cmd_send -v --host=${{ steps.check-cpu1.outputs.ip-addr }} --endian=EDS --pktid=CFE_ES/Application/CMD --cmdcode=RestartCmd RestartType=2
+          ./cmd_send -v --host="${STEP_CHECK_CPU1_IP_ADDR}" --endian=EDS --pktid=CFE_ES/Application/CMD --cmdcode=RestartCmd RestartType=2
           sleep 2
 
       - name: Capture Logs
         if: ${{ always() && steps.start-cpu1.outputs.container-id != '' }}
-        run: docker logs ${{ steps.start-cpu1.outputs.container-id }} > ${{ matrix.variant }}/cFS_startup_cpu1.txt
+        env:
+          STEP_START_CPU1_CONTAINER_ID: ${{ steps.start-cpu1.outputs.container-id }}
+          MATRIX_VARIANT: ${{ matrix.variant }}
+        run: docker logs "$STEP_START_CPU1_CONTAINER_ID" > "${MATRIX_VARIANT}/cFS_startup_cpu1.txt"
 
       - name: Stop CPU1 Container
         #if: ${{ always() && steps.start-cpu1.outputs.container-id != '' }}
@@ -238,21 +261,25 @@ jobs:
           path: ${{ matrix.variant }}/cFS_startup_cpu1.txt
 
       - name: Confirm startup string
+        env:
+          MATRIX_VARIANT: ${{ matrix.variant }}
         run: |
-          if [[ -z $(grep "$START_STRING" ${{ matrix.variant }}/cFS_startup_cpu1.txt) ]]; then
+          if [[ -z $(grep "$START_STRING" "${MATRIX_VARIANT}/cFS_startup_cpu1.txt") ]]; then
             echo "Startup verification string not found in log: $START_STRING"
             echo ""
             echo "Possible related event messages:"
-            grep "/$APP_UPPER " ${{ matrix.variant }}/cFS_startup_cpu1.txt
+            grep "/$APP_UPPER " "${MATRIX_VARIANT}/cFS_startup_cpu1.txt"
             exit -1
           fi
 
       - name: Check for cFS Warnings
         if: success() || failure()
+        env:
+          MATRIX_VARIANT: ${{ matrix.variant }}
         run: |
-          if [[ -n $(grep -i "warn\|err\|fail" ${{ matrix.variant }}/cFS_startup_cpu1.txt) ]]; then
+          if [[ -n $(grep -i "warn\|err\|fail" "${MATRIX_VARIANT}/cFS_startup_cpu1.txt") ]]; then
                   echo "cFS startup warn|err|fail:"
                   echo ""
-                  grep -i 'warn\|err\|fail' ${{ matrix.variant }}/cFS_startup_cpu1.txt
+                  grep -i 'warn\|err\|fail' "${MATRIX_VARIANT}/cFS_startup_cpu1.txt"
                   exit -1
           fi

--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -134,12 +134,16 @@ jobs:
       # For osal
       - name: Setup Build
         if: inputs.component-path == 'osal'
+        env:
+          INPUT_SETUP: ${{ inputs.setup }}
         run: |
-          ${{ inputs.setup }}
+          bash -e -o pipefail -c "$INPUT_SETUP"
 
       - name: Prep Build
+        env:
+          INPUT_PREP: ${{ inputs.prep }}
         run: |
-          ${{ inputs.prep }}
+          bash -e -o pipefail -c "$INPUT_PREP"
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
@@ -148,7 +152,9 @@ jobs:
           config-file: nasa/cFS/.github/codeql/codeql-${{matrix.scan-type}}.yml@main
 
       - name: Build
-        run: ${{ inputs.make }}
+        env:
+          INPUT_MAKE: ${{ inputs.make }}
+        run: bash -e -o pipefail -c "$INPUT_MAKE"
         working-directory: ${{env.BUILD_DIRECTORY}}
 
       - name: Perform CodeQL Analysis
@@ -159,9 +165,11 @@ jobs:
           output: CodeQL-Sarif-${{ matrix.scan-type }}
 
       - name: Rename Sarif
+        env:
+          MATRIX_SCAN_TYPE: ${{ matrix.scan-type }}
         run: |
-          mv CodeQL-Sarif-${{ matrix.scan-type }}/cpp.sarif CodeQL-Sarif-${{ matrix.scan-type }}/Codeql-${{ matrix.scan-type }}.sarif
-          sed -i 's/"name" : "CodeQL"/"name" : "CodeQL-${{ matrix.scan-type }}"/g' CodeQL-Sarif-${{ matrix.scan-type }}/Codeql-${{ matrix.scan-type }}.sarif
+          mv "CodeQL-Sarif-${MATRIX_SCAN_TYPE}/cpp.sarif" "CodeQL-Sarif-${MATRIX_SCAN_TYPE}/Codeql-${MATRIX_SCAN_TYPE}.sarif"
+          sed -i "s/\"name\" : \"CodeQL\"/\"name\" : \"CodeQL-${MATRIX_SCAN_TYPE}\"/g" "CodeQL-Sarif-${MATRIX_SCAN_TYPE}/Codeql-${MATRIX_SCAN_TYPE}.sarif"
 
       - name: filter-sarif
         uses: advanced-security/filter-sarif@v1

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -45,7 +45,7 @@ jobs:
           path: repo
 
       - name: Get style from bundle
-        run: curl -fsL ${{ github.server_url }}/nasa/cFS/raw/refs/heads/dev/.clang-format > $GITHUB_WORKSPACE/clang-format.yml
+        run: curl -fsL "${GITHUB_SERVER_URL}/nasa/cFS/raw/refs/heads/dev/.clang-format" > "$GITHUB_WORKSPACE/clang-format.yml"
 
       - name: Check configuration
         run: clang-format-19 -style=file:$GITHUB_WORKSPACE/clang-format.yml --dump-config

--- a/.github/workflows/mcdc-reusable.yml
+++ b/.github/workflows/mcdc-reusable.yml
@@ -64,7 +64,7 @@ jobs:
           echo "BUILD_SUBDIR=build/native/default_cpu1/apps/$APP_LOWER" >> $GITHUB_ENV
 
       - name: Fetch MCDC Check Script
-        run: wget -nv -O mcdc-analyze.sh ${{ github.server_url }}/nasa/cFS/raw/refs/heads/dev/.github/scripts/mcdc-analyze.sh
+        run: wget -nv -O mcdc-analyze.sh "${GITHUB_SERVER_URL}/nasa/cFS/raw/refs/heads/dev/.github/scripts/mcdc-analyze.sh"
 
       - name: Include conditional coverage flags
         run: |

--- a/.github/workflows/test-cfs-qemu.yml
+++ b/.github/workflows/test-cfs-qemu.yml
@@ -45,16 +45,24 @@ jobs:
           submodules: true
 
       - name: Prepare ${{ matrix.config }} Build
-        run: make ${{ matrix.config }}.prep
+        env:
+          MATRIX_CONFIG: ${{ matrix.config }}
+        run: make "${MATRIX_CONFIG}.prep"
 
       - name: Build ${{ matrix.doctype }} documentation
-        run: make ${{ matrix.config }}.${{ matrix.doctype }}
+        env:
+          MATRIX_CONFIG: ${{ matrix.config }}
+          MATRIX_DOCTYPE: ${{ matrix.doctype }}
+        run: make "${MATRIX_CONFIG}.${MATRIX_DOCTYPE}"
 
       - name: Set environment
+        env:
+          MATRIX_CONFIG: ${{ matrix.config }}
+          MATRIX_PATH: ${{ matrix.path }}
         run: |
-          echo "FULL_WARNING_LOG=build-${{ matrix.config }}/docs/${{ matrix.path }}/${{ matrix.path }}-warnings.log" >> $GITHUB_ENV
-          echo "SCRUBBED_WARNING_LOG=build-${{ matrix.config }}/${{ matrix.path }}-internal-warnings.log" >> $GITHUB_ENV
-          echo "OTHER_WARNING_LOG=build-${{ matrix.config }}/${{ matrix.path }}-other-warnings.log" >> $GITHUB_ENV
+          echo "FULL_WARNING_LOG=build-${MATRIX_CONFIG}/docs/${MATRIX_PATH}/${MATRIX_PATH}-warnings.log" >> $GITHUB_ENV
+          echo "SCRUBBED_WARNING_LOG=build-${MATRIX_CONFIG}/${MATRIX_PATH}-internal-warnings.log" >> $GITHUB_ENV
+          echo "OTHER_WARNING_LOG=build-${MATRIX_CONFIG}/${MATRIX_PATH}-other-warnings.log" >> $GITHUB_ENV
 
 
       # the intent of this is to separate the warnings into those caused by submodule problems vs those caused
@@ -156,9 +164,11 @@ jobs:
           path: ${{ matrix.config }}-bin
 
       - name: Unpack target runtime images
+        env:
+          MATRIX_CONFIG: ${{ matrix.config }}
         run: |
           ls -lR
-          for tarball in $GITHUB_WORKSPACE/${{ matrix.config }}-bin/*.tar.gz
+          for tarball in $GITHUB_WORKSPACE/${MATRIX_CONFIG}-bin/*.tar.gz
           do
             inst=$(basename ${tarball})
             echo tarball=${tarball} inst=${inst}
@@ -186,16 +196,18 @@ jobs:
       - name: Setup log retrieval via SSH
         if: matrix.log-fetch-method == 'ssh'
         shell: bash
+        env:
+          STEP_CHECK_CPU1_IP_ADDR: ${{ steps.check-cpu1.outputs.ip-addr }}
         run: |
           mkdir -p ~/.ssh
           chmod 0700 ~/.ssh
           touch ~/.ssh/known_hosts
           chmod 0600 ~/.ssh/known_hosts
-          ssh-keyscan -p 2222 ${{ steps.check-cpu1.outputs.ip-addr }} >> ~/.ssh/known_hosts
+          ssh-keyscan -p 2222 "$STEP_CHECK_CPU1_IP_ADDR" >> ~/.ssh/known_hosts
           cat ~/.ssh/known_hosts
           cat > ./fetch_logs.sh << EOF
           #!/bin/bash
-          ssh -p 2222 root@${{ steps.check-cpu1.outputs.ip-addr }} grep 'user\.notice CFS:' /var/log/messages | sed -e 's/^.*user\.notice CFS: //'
+          ssh -p 2222 "root@${STEP_CHECK_CPU1_IP_ADDR}" grep 'user\.notice CFS:' /var/log/messages | sed -e 's/^.*user\.notice CFS: //'
           EOF
           chmod +x ./fetch_logs.sh
           cat ./fetch_logs.sh
@@ -203,19 +215,25 @@ jobs:
       - name: Setup direct log retrieval
         if: matrix.log-fetch-method == 'direct'
         shell: bash
+        env:
+          STEP_START_CPU1_CONTAINER_ID: ${{ steps.start-cpu1.outputs.container-id }}
         run: |
           cat > ./fetch_logs.sh << EOF
           #!/bin/bash
-          docker logs "${{ steps.start-cpu1.outputs.container-id }}"
+          docker logs "${STEP_START_CPU1_CONTAINER_ID}"
           EOF
           chmod +x ./fetch_logs.sh
           cat ./fetch_logs.sh
 
       - name: Setup Environment
         if: matrix.log-fetch-method != ''
+        env:
+          MATRIX_TEST_PROCEDURE: ${{ matrix.test-procedure }}
+          MATRIX_ES_MID: ${{ matrix.es-mid }}
+          STEP_CHECK_CPU1_IP_ADDR: ${{ steps.check-cpu1.outputs.ip-addr }}
         run: |
-          TEST_PROCEDURE=${{ matrix.test-procedure }}
-          CMDSEND_ES_MID=${{ matrix.es-mid }}
+          TEST_PROCEDURE=${MATRIX_TEST_PROCEDURE}
+          CMDSEND_ES_MID=${MATRIX_ES_MID}
           case "${TEST_PROCEDURE%%_*}" in
             "eds")
               CMDSEND_ES_MID_DEFAULT="CFE_ES/Application/CMD"
@@ -231,7 +249,7 @@ jobs:
           echo "CMDSEND_ES_MID=${CMDSEND_ES_MID:-$CMDSEND_ES_MID_DEFAULT}" >> $GITHUB_ENV
           echo "CMDSEND_NOOP_CMDCODE=${CMDSEND_NOOP_CMDCODE:-0}" >> $GITHUB_ENV
           echo "CMDSEND_ENDIAN=${CMDSEND_ENDIAN:-LE}" >> $GITHUB_ENV
-          echo "CMDSEND_IP_ADDR=${{ steps.check-cpu1.outputs.ip-addr }}" >> $GITHUB_ENV
+          echo "CMDSEND_IP_ADDR=${STEP_CHECK_CPU1_IP_ADDR}" >> $GITHUB_ENV
 
       - name: Execute cpu1 test
         if: env.CMDSEND_IP_ADDR != ''

--- a/.github/workflows/unit-test-coverage-reusable.yml
+++ b/.github/workflows/unit-test-coverage-reusable.yml
@@ -57,10 +57,13 @@ jobs:
     steps:
       - name: Set up environment variables
         # Apps typically use lowercase targets and uppercase names, this logic is fragile but works
+        env:
+          INPUT_APP_NAME: ${{ inputs.app-name }}
+          INPUT_DEPENDENCY: ${{ inputs.dependency }}
         run: |
-          echo "APP_UPPER=$(echo ${{ inputs.app-name }} | sed 's/[a-z]/\U&/g')" >> $GITHUB_ENV
-          echo "APP_LOWER=$(echo ${{ inputs.app-name }} | sed 's/[A-Z]/\L&/g')" >> $GITHUB_ENV
-          APP_DEP="${{ inputs.dependency }}"
+          echo "APP_UPPER=$(echo "$INPUT_APP_NAME" | sed 's/[a-z]/\U&/g')" >> $GITHUB_ENV
+          echo "APP_LOWER=$(echo "$INPUT_APP_NAME" | sed 's/[A-Z]/\L&/g')" >> $GITHUB_ENV
+          APP_DEP="${INPUT_DEPENDENCY}"
           echo "APP_DEP_UPPER=$(echo ${APP_DEP##*/} | sed 's/[a-z]/\U&/g')" >> $GITHUB_ENV
           echo "APP_DEP_LOWER=$(echo ${APP_DEP##*/} | sed 's/[A-Z]/\L&/g')" >> $GITHUB_ENV
 
@@ -131,17 +134,20 @@ jobs:
           genhtml coverage_total.info --branch-coverage --output-directory lcov | tee lcov_out.txt
 
       - name: Confirm minimum coverage
+        env:
+          INPUT_MAX_MISSED_BRANCHES: ${{ inputs.max-missed-branches }}
+          INPUT_MAX_MISSED_LINES: ${{ inputs.max-missed-lines }}
         run: |
           branch_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep branches | grep -oP "[0-9]+[0-9]*")
           line_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep lines | grep -oP "[0-9]+[0-9]*")
 
           branch_diff=$(echo $branch_nums | awk '{ print $4 - $3 }')
           line_diff=$(echo $line_nums | awk '{ print $4 - $3 }')
-          if [ $branch_diff -gt ${{ inputs.max-missed-branches }} ] || [ $line_diff -gt ${{ inputs.max-missed-lines }} ]
+          if [ $branch_diff -gt ${INPUT_MAX_MISSED_BRANCHES} ] || [ $line_diff -gt ${INPUT_MAX_MISSED_LINES} ]
           then
             grep -A 3 "Overall coverage rate" lcov_out.txt
-            echo "$branch_diff branches missed, ${{ inputs.max-missed-branches }} allowed"
-            echo "$line_diff lines missed, ${{ inputs.max-missed-lines }} allowed"
+            echo "$branch_diff branches missed, ${INPUT_MAX_MISSED_BRANCHES} allowed"
+            echo "$line_diff lines missed, ${INPUT_MAX_MISSED_LINES} allowed"
             exit -1
           fi
 

--- a/.github/workflows/update-bundle.yml
+++ b/.github/workflows/update-bundle.yml
@@ -79,10 +79,12 @@ jobs:
 
       - name: Create integration branch
         if: steps.status-check.outputs.branch-name != ''
+        env:
+          STEP_STATUS_CHECK_BRANCH_NAME: ${{ steps.status-check.outputs.branch-name }}
         run: |
             git config --global user.email "actions@developer.nasa.gov"
             git config --global user.name "Github Action"
-            git checkout -b "${{ steps.status-check.outputs.branch-name }}"
+            git checkout -b "${STEP_STATUS_CHECK_BRANCH_NAME}"
             cat << EOF > ${RUNNER_TEMP}/commit-msg.txt
             Integration Candidate: $(date +%Y-%m-%d) bundle updates
 
@@ -91,13 +93,15 @@ jobs:
               - bundle branch: to ${BASE_BRANCH}
             EOF
             git commit -a -F ${RUNNER_TEMP}/commit-msg.txt
-            git push origin -f "${{ steps.status-check.outputs.branch-name }}"
+            git push origin -f "${STEP_STATUS_CHECK_BRANCH_NAME}"
 
       - name: Create pull request
         if: steps.status-check.outputs.branch-name != ''
+        env:
+          STEP_STATUS_CHECK_BRANCH_NAME: ${{ steps.status-check.outputs.branch-name }}
         run: |
             if [ -e ${RUNNER_TEMP}/pull-request.json ]; then
-              echo "Pull request already exists: ${{ github.server_url }}/${GH_REPO}/pull/$(jq '.[0].number' ${RUNNER_TEMP}/pull-request.json)"
+              echo "Pull request already exists: ${GITHUB_SERVER_URL}/${GH_REPO}/pull/$(jq '.[0].number' ${RUNNER_TEMP}/pull-request.json)"
             else
-              gh pr create -B "${BASE_BRANCH}" -H "${{ steps.status-check.outputs.branch-name }}" --title "Latest bundle updates from ${SUBMODULE_BRANCH} branch" --body 'Created by Github action'
+              gh pr create -B "${BASE_BRANCH}" -H "${STEP_STATUS_CHECK_BRANCH_NAME}" --title "Latest bundle updates from ${SUBMODULE_BRANCH} branch" --body 'Created by Github action'
             fi

--- a/actions/build-app/action.yml
+++ b/actions/build-app/action.yml
@@ -23,11 +23,15 @@ runs:
   steps:
     - name: Setup environment
       shell: bash
-      run: echo "DESTDIR=$GITHUB_WORKSPACE/staging${{ inputs.tag }}" >> $GITHUB_ENV
+      env:
+        INPUT_TAG: ${{ inputs.tag }}
+      run: echo "DESTDIR=${GITHUB_WORKSPACE}/staging${INPUT_TAG}" >> "$GITHUB_ENV"
 
     - name: Make install
       shell: bash
-      run: make -C build${{ inputs.tag }} mission-install
+      env:
+        INPUT_TAG: ${{ inputs.tag }}
+      run: make -C "build${INPUT_TAG}" mission-install
 
     - name: Create startup link
       shell: bash
@@ -36,8 +40,10 @@ runs:
     - name: Override startup script
       if: inputs.startup-script != ''
       shell: bash
+      env:
+        INPUT_STARTUP_SCRIPT: ${{ inputs.startup-script }}
       run: |
-        cp ${GITHUB_WORKSPACE}/${{ inputs.startup-script }} ${DESTDIR}/exe/cpu1/cf/cfe_es_startup.scr
+        cp "${GITHUB_WORKSPACE}/${INPUT_STARTUP_SCRIPT}" "${DESTDIR}/exe/cpu1/cf/cfe_es_startup.scr"
 
     - name: Create CPU1 tarball
       shell: bash

--- a/actions/cppcheck/action.yml
+++ b/actions/cppcheck/action.yml
@@ -28,17 +28,21 @@ runs:
   steps:
     - name: Fetch conversion XSLT
       shell: bash
+      env:
+        INPUT_CPPCHECK_XSLT_PATH: ${{ inputs.cppcheck-xslt-path }}
       run: |
-        wget -O cppcheck-xml2text.xslt ${{ github.server_url }}/${{ inputs.cppcheck-xslt-path }}/cppcheck-xml2text.xslt
-        wget -O cppcheck-merge.xslt ${{ github.server_url }}/${{ inputs.cppcheck-xslt-path }}/cppcheck-merge.xslt
+        wget -O cppcheck-xml2text.xslt "${GITHUB_SERVER_URL}/${INPUT_CPPCHECK_XSLT_PATH}/cppcheck-xml2text.xslt"
+        wget -O cppcheck-merge.xslt "${GITHUB_SERVER_URL}/${INPUT_CPPCHECK_XSLT_PATH}/cppcheck-merge.xslt"
 
       # If source dirs are specified, just pass them through.  This will examine all .c files in the repo,
       # but it will not see the macro definitions, and thus may not correctly interpret macro usage.
     - name: Source Directory Setup
       if: ${{ inputs.source-dir != '' }}
       shell: bash
+      env:
+        INPUT_SOURCE_DIR: ${{ inputs.source-dir }}
       run: |
-        echo CPPCHECK_OPTS=${{ inputs.source-dir }} >> $GITHUB_ENV
+        echo "CPPCHECK_OPTS=${INPUT_SOURCE_DIR}" >> "$GITHUB_ENV"
 
       # Get the list of files by setting up a build with CMAKE_EXPORT_COMPILE_COMMANDS=ON and
       # referencing the compile_commands.json file produced by the tool.  This will capture the
@@ -46,10 +50,13 @@ runs:
     - name: Compile Commands Setup
       if: ${{ inputs.compile-commands-json != '' }}
       shell: bash
+      env:
+        INPUT_MODULE_PATH: ${{ inputs.module-path }}
+        INPUT_COMPILE_COMMANDS_JSON: ${{ inputs.compile-commands-json }}
       run: |
-        MODULE_PATH=$(realpath $GITHUB_WORKSPACE/${{ inputs.module-path }})
+        MODULE_PATH=$(realpath "$GITHUB_WORKSPACE/${INPUT_MODULE_PATH}")
         echo filtering on $MODULE_PATH
-        jq '[.[] | if (.file | startswith("'$MODULE_PATH'")) then . else empty end]' ${{ inputs.compile-commands-json }} > local-cppcheck-compile-commands.json
+        jq '[.[] | if (.file | startswith("'$MODULE_PATH'")) then . else empty end]' "${INPUT_COMPILE_COMMANDS_JSON}" > local-cppcheck-compile-commands.json
         echo CPPCHECK_OPTS=--project=local-cppcheck-compile-commands.json >> $GITHUB_ENV
 
     - name: Run general cppcheck
@@ -62,9 +69,11 @@ runs:
     - name: Run Strict cppcheck
       if: ${{ inputs.strict-dir-list !='' }}
       shell: bash
+      env:
+        INPUT_STRICT_DIR_LIST: ${{ inputs.strict-dir-list }}
       run: |
         mv cppcheck_err.xml general_cppcheck_err.xml
-        cppcheck --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive --xml ${{ inputs.strict-dir-list }} 2> strict_cppcheck_err.xml
+        cppcheck --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive --xml ${INPUT_STRICT_DIR_LIST} 2> strict_cppcheck_err.xml
         xsltproc --stringparam merge_file strict_cppcheck_err.xml cppcheck-merge.xslt general_cppcheck_err.xml > cppcheck_err.xml
 
     - name: Convert cppcheck results to Markdown

--- a/actions/healthcheck-logs/action.yml
+++ b/actions/healthcheck-logs/action.yml
@@ -23,24 +23,30 @@ runs:
   steps:
     - name: Check for boot completion
       shell: bash
+      env:
+        INPUT_CONTAINER_ID: ${{ inputs.container-id }}
+        INPUT_HEALTHCHECK_REGEX: ${{ inputs.healthcheck-regex }}
       run: |
         count=0
-        docker logs "${{ inputs.container-id }}" > ${{ inputs.container-id }}_logs.txt
-        while [ $count -lt 30 ] && ! grep -q '${{ inputs.healthcheck-regex }}' ${{ inputs.container-id }}_logs.txt
+        LOG_FILE="${INPUT_CONTAINER_ID}_logs.txt"
+        docker logs "$INPUT_CONTAINER_ID" > "$LOG_FILE"
+        while [ $count -lt 30 ] && ! grep -q -- "$INPUT_HEALTHCHECK_REGEX" "$LOG_FILE"
         do
           sleep 2
           count=$(($count+1))
-          docker logs "${{ inputs.container-id }}" > ${{ inputs.container-id }}_logs.txt
+          docker logs "$INPUT_CONTAINER_ID" > "$LOG_FILE"
         done
         echo "Boot log after ${count} iterations:"
-        cat ${{ inputs.container-id }}_logs.txt
-        grep -q '${{ inputs.healthcheck-regex }}' ${{ inputs.container-id }}_logs.txt
+        cat "$LOG_FILE"
+        grep -q -- "$INPUT_HEALTHCHECK_REGEX" "$LOG_FILE"
 
     - name: Get IP address of container
       shell: bash
       id: query-ip-addr
+      env:
+        INPUT_CONTAINER_ID: ${{ inputs.container-id }}
       run: |
-        IP_ADDR=$(docker inspect "${{ inputs.container-id }}" \
+        IP_ADDR=$(docker inspect "${INPUT_CONTAINER_ID}" \
           --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
         echo "addr=$IP_ADDR" >> $GITHUB_OUTPUT
         echo "Container IP: $IP_ADDR"
@@ -48,12 +54,14 @@ runs:
     - name: Get SSH key
       if: fromJSON(inputs.ssh-keyscan)
       shell: bash
+      env:
+        INPUT_CONTAINER_ID: ${{ inputs.container-id }}
       run: |
         mkdir -p ~/.ssh
         chmod 0700 ~/.ssh
         touch ~/.ssh/known_hosts
         chmod 0600 ~/.ssh/known_hosts
-        IP_ADDR=$(docker inspect "${{ inputs.container-id }}" \
+        IP_ADDR=$(docker inspect "${INPUT_CONTAINER_ID}" \
           --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
         ssh-keyscan -p 2222 "$IP_ADDR" | tee -a ~/.ssh/known_hosts
         cat ~/.ssh/known_hosts

--- a/actions/setup-app/action.yml
+++ b/actions/setup-app/action.yml
@@ -34,13 +34,17 @@ runs:
     - name: Set up environment variables
       # Apps typically use lowercase targets and uppercase names, this logic is fragile but works
       shell: bash
+      env:
+        INPUT_APP_NAME: ${{ inputs.app-name }}
+        INPUT_DEPENDENCY: ${{ inputs.dependency }}
+        INPUT_CONFIG_NAME: ${{ inputs.config-name }}
       run: |
-        echo "APP_UPPER=$(echo ${{ inputs.app-name }} | sed 's/[a-z]/\U&/g')" >> $GITHUB_ENV
-        echo "APP_LOWER=$(echo ${{ inputs.app-name }} | sed 's/[A-Z]/\L&/g')" >> $GITHUB_ENV
-        APP_DEP="${{ inputs.dependency }}"
+        echo "APP_UPPER=$(echo "$INPUT_APP_NAME" | sed 's/[a-z]/\U&/g')" >> $GITHUB_ENV
+        echo "APP_LOWER=$(echo "$INPUT_APP_NAME" | sed 's/[A-Z]/\L&/g')" >> $GITHUB_ENV
+        APP_DEP="$INPUT_DEPENDENCY"
         echo "APP_DEP_UPPER=$(echo ${APP_DEP##*/} | sed 's/[a-z]/\U&/g')" >> $GITHUB_ENV
         echo "APP_DEP_LOWER=$(echo ${APP_DEP##*/} | sed 's/[A-Z]/\L&/g')" >> $GITHUB_ENV
-        echo "CONFIG_NAME=${{ inputs.config-name }}" >> $GITHUB_ENV
+        echo "CONFIG_NAME=${INPUT_CONFIG_NAME}" >> "$GITHUB_ENV"
         echo "STD_BUILDDIR=build" >> $GITHUB_ENV
 
     # if EDS is enabled then prepare for two separate build dirs
@@ -106,10 +110,12 @@ runs:
     - name: Set up build tree (eds)
       if: fromJSON(inputs.enable-eds)
       shell: bash
+      env:
+        INPUT_CMAKE_OPTIONS: ${{ inputs.cmake-options }}
       run: |
         export DESTDIR=$GITHUB_WORKSPACE/${EDS_BUILDDIR}
         mkdir -p ${DESTDIR}
-        cd ${DESTDIR} && cmake ${{ inputs.cmake-options }} \
+        cd ${DESTDIR} && cmake ${INPUT_CMAKE_OPTIONS} \
           -DCFE_EDS_ENABLED=ON \
           -DEDSLIB_PYTHON_BUILD_STANDALONE_MODULE=ON \
           -DCFE_MISSIONLIB_PYTHON_BUILD_STANDALONE_MODULE=ON \
@@ -117,7 +123,9 @@ runs:
 
     - name: Set up build tree (std)
       shell: bash
+      env:
+        INPUT_CMAKE_OPTIONS: ${{ inputs.cmake-options }}
       run: |
         export DESTDIR=$GITHUB_WORKSPACE/${STD_BUILDDIR}
         mkdir -p ${DESTDIR}
-        cd ${DESTDIR} && cmake ${{ inputs.cmake-options }} "$GITHUB_WORKSPACE/cfe"
+        cd ${DESTDIR} && cmake ${INPUT_CMAKE_OPTIONS} "$GITHUB_WORKSPACE/cfe"

--- a/actions/start-cfs-container/action.yml
+++ b/actions/start-cfs-container/action.yml
@@ -20,17 +20,22 @@ runs:
   steps:
     - name: Pull CFS container
       shell: bash
-      run: docker pull ${{ inputs.exec-image }}
+      env:
+        INPUT_EXEC_IMAGE: ${{ inputs.exec-image }}
+      run: docker pull "$INPUT_EXEC_IMAGE"
 
     - name: Start cFS execution container
       shell: bash
       id: start-container
+      env:
+        INPUT_BINARY_DIR: ${{ inputs.binary-dir }}
+        INPUT_EXEC_IMAGE: ${{ inputs.exec-image }}
       run: |
         DOCKER_ID=$(docker run -d \
-          -v ${{ inputs.binary-dir }}:${{ inputs.binary-dir }} \
+          -v "${INPUT_BINARY_DIR}:${INPUT_BINARY_DIR}" \
           --sysctl fs.mqueue.msg_max=64 \
-          -w ${{ inputs.binary-dir }} \
-          ${{ inputs.exec-image }} \
+          -w "$INPUT_BINARY_DIR" \
+          "$INPUT_EXEC_IMAGE" \
           ./container-start)
         echo "id=$DOCKER_ID" >> $GITHUB_OUTPUT
         echo "Started Container: $DOCKER_ID"

--- a/actions/stop-cfs-container/action.yml
+++ b/actions/stop-cfs-container/action.yml
@@ -12,12 +12,16 @@ runs:
     - name: Stop container
       if: inputs.container-id != ''
       shell: bash
-      run: docker stop "${{ inputs.container-id }}"
+      env:
+        INPUT_CONTAINER_ID: ${{ inputs.container-id }}
+      run: docker stop "${INPUT_CONTAINER_ID}"
 
     - name: Remove container
       if: inputs.container-id != ''
       shell: bash
-      run: docker rm "${{ inputs.container-id }}"
+      env:
+        INPUT_CONTAINER_ID: ${{ inputs.container-id }}
+      run: docker rm "${INPUT_CONTAINER_ID}"
 
     - name: List Containers
       shell: bash


### PR DESCRIPTION
## Description of Change

Replace direct GitHub expression interpolation inside shell `run:` steps across the cFS workflows and composite actions with step environment variables.

This keeps expression values out of generated shell source so they are treated as data rather than shell syntax. Path, regex, container, and configuration values are quoted at shell boundaries. The CodeQL `setup`, `prep`, and `make` inputs intentionally carry command strings, so those are executed explicitly with `bash -e -o pipefail -c "$INPUT_*"` to preserve their existing semantics without interpolating GitHub expressions into the shell script.

The change covers 15 workflow/composite-action files and reduces direct `${{ ... }}` interpolation inside `run:` blocks from 114 occurrences to 0.

## Linked Issue

Part of #1029

## Areas of Expertise Touched

- [ ] ASTRO
- [x] CI/CD
- [ ] COSMOS
- [x] Cybersecurity
- [x] Docker
- [ ] EDS
- [x] Git
- [ ] PSPs
- [ ] SBN
- [ ] SMP
- [ ] Tables
- [ ] TSN
- [ ] Unit Tests
- [ ] Other

---

## Author Checklist

- [x] Linked GitHub issue is referenced above
- [x] Workflow changes were tested on a branch/fork before submitting this PR
- [ ] All workflows ran successfully on this branch

Validation performed on the fork before submission:

- audited 114 direct expression interpolations in `run:` blocks before the change and 0 after
- parsed all modified workflow and composite-action YAML successfully
- compared actionlint and ShellCheck diagnostics before and after the patch, with no new findings introduced
- `git diff --check` passed

Upstream GitHub Actions are currently awaiting maintainer authorization for this fork-originated pull request, so no upstream CI result is being claimed yet.

---

## Reviewer Checklist

- [ ] Workflow logic is correct and achieves the stated goal
- [ ] Third-party actions are from trusted sources and pinned to a specific SHA/tag
- [ ] Secrets are handled appropriately (no secrets exposed in logs, least-privilege usage)
- [ ] Workflow permissions follow the principle of least privilege
- [ ] Changes do not break or bypass existing branch protection rules
- [ ] All workflow runs on this PR completed successfully
- [ ] Appropriate Expert areas have been reviewed


### Latest rebase validation

Rebased onto current `dev`, preserving the new application-specific documentation warning filter. Also moved the newly added build-tag expression into a step environment variable. All 15 changed YAML files parse, all 114 shell steps pass Bash syntax checks, and actionlint reports the same seven pre-existing findings before and after. Direct GitHub expressions in those run blocks fall from 114 to zero. `git diff --check` passed; full workflow execution remains pending.
