### PR TITLE
Fix #1097, filter doc warnings to subject app

### DIFF
--- a/.github/workflows/build-doc-reusable.yml
+++ b/.github/workflows/build-doc-reusable.yml
@@ -91,7 +91,17 @@ jobs:
       - name: Build Document
         run: |
           make -C build ${{ matrix.target }} 2>&1 > ${{ matrix.target }}_stdout.txt | tee ${{ matrix.target }}_stderr.txt
-          mv build/docs/${{ matrix.target }}/${{ matrix.target }}-warnings.log .
+
+      - name: Filter warnings
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          APP_NAME: ${{ inputs.app-name }}
+          IN_FILE: ./build/docs/${{ matrix.target }}/${{ matrix.target }}-warnings.log
+          OUT_FILE: ./${{ matrix.target }}-warnings.log
+        run: |
+          app_path=$(grep -A1 "^${APP_NAME}_MISSION_DIR" build/mission_vars.cache | tail -1 || echo .)
+          echo "filtering warnings by app_path=${app_path}"
+          grep "^${app_path}" "${IN_FILE}" | tee "${OUT_FILE}" || /bin/true
 
       - name: Archive Document Build Logs
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**

Grep the documentation warnings to contain only those lines which
reference the current subject app path.  The intent is to only fail the
documentation workflow if errors/warnings are triggered by code within
the same submodule as is triggering the workflow.

This is to avoid having a doc bug in cFE cause the doc workflows for
every submodule to fail.

Fixes #1097

**Testing performed**
Build FM docs while the error in CFE is still present (nasa/cFE#2797)

**Expected behavior changes**
FM docs build OK but the cFE error is still there.

**System(s) tested on**
Workflows

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.