### PR TITLE
Closes #1101: Test tables not being built and installed

### DIFF
--- a/sample_defs/cpu1/install_custom.cmake
+++ b/sample_defs/cpu1/install_custom.cmake
@@ -41,6 +41,8 @@ add_cfe_tables(sample_app sample_app_alt1.c)
 add_cfe_tables(to_lab to_lab_sub_alt.c)
 add_cfe_tables(to_lab to_lab_sub_bad.c)
 add_cfe_tables(lc lc_def_adt-test.c)
+add_cfe_tables(sc sc_ats2_test.c)
+add_cfe_tables(sc sc_append_test.c)
 
 # This executes the startup script generator
 install(SCRIPT ${MISSION_DEFS}/generate_startup.cmake)

--- a/sample_defs/cpu2/install_custom.cmake
+++ b/sample_defs/cpu2/install_custom.cmake
@@ -41,6 +41,8 @@ add_cfe_tables(sample_app sample_app_alt1.c)
 add_cfe_tables(to_lab to_lab_sub_alt.c)
 add_cfe_tables(to_lab to_lab_sub_bad.c)
 add_cfe_tables(lc lc_def_adt-test.c)
+add_cfe_tables(sc sc_ats2_test.c)
+add_cfe_tables(sc sc_append_test.c)
 
 # This executes the startup script generator
 install(SCRIPT ${MISSION_DEFS}/generate_startup.cmake)


### PR DESCRIPTION
---
name: FSW Code Change
about: Flight Software code changes
labels: fsw
---

## Description of Change
Adding in test tables that were left out of the build's makefiles.

## Linked Issue

Closes #1101 

## Requirements Impact

<!-- List any requirements impacted by this change. Indicate whether each was updated, or confirm the change continues to satisfy existing requirements. -->
- Requirement ID(s):
- [ ] Requirements updated as necessary
- [x] Existing requirements are still satisfied by this change

## Testing Evidence
Steps taken to test the contribution:
1. Checked out the branch where the work was done
2. Built, from scratch, the cFS with native_std target
3. Ran the SC COSMOS test against it
    - The test loaded the tables like it should have. (Other issues are open to fix the rest)

### COSMOS Test Suite
cfs_test_suite.py running cfs_sc.py

## Areas of Expertise Touched

- [ ] ASTRO
- [ ] CI/CD
- [x] COSMOS
- [ ] Cybersecurity
- [ ] Docker
- [ ] EDS
- [ ] Git
- [ ] PSPs
- [ ] SBN
- [ ] SMP
- [x] Tables
- [ ] TSN
- [ ] Unit Tests
- [ ] Other

---

## Author Checklist

- [x] Linked GitHub issue is referenced above
- [x] Code has been formatted with `.clang-format`
- [ N/A ] Static analysis workflows ran and passed
- [ N/A ] Unit tests (UT Assert) updated/added to cover code changes
- [ N/A ] Unit test workflows ran and passed
- [x] COSMOS test suite was run; tests updated/added if relevant changes were made
- [ N/A ] Requirements have been reviewed; updated or confirmed still satisfied (see above)
- [x] Testing evidence is included above
- [x] Self-review of the diff completed

---

## Reviewer Checklist

- [x] Code logic is correct and matches the stated intent
- [x] Code is readable, maintainable, and follows project conventions
- [x] `.clang-format` has been applied
- [ N/A ] Static analysis results reviewed and acceptable
- [ N/A ] Unit tests are meaningful and adequately cover the changes
- [ N/A ] **The change has been exercised by the unit tests** (not just that tests pass — the new/changed code paths are actually covered)
- [x] **COSMOS test suite was executed against this change** and results reviewed (or confirmed N/A with justification)
- [x] **Reviewer has independently verified the change behaves as described** (e.g., by running the tests locally, reviewing CI output in detail, or performing additional ad-hoc testing as warranted)
- [ N/A ] **Memory safety** reviewed (allocation, bounds, lifetime, stack usage)
- [ N/A ] Requirements impact reviewed and appropriate
- [ N/A ] Error handling is appropriate
- [x] Appropriate Expert areas have been reviewed

### Reviewer Testing Notes
<!--
Describe how you independently verified this change. For example:
  - "Pulled the branch locally, ran `make test`, all UT Assert tests passed including the new ones for X."
  - "Ran the COSMOS test suite against the branch; observed expected telemetry behavior for Y."
  - "Reviewed CI run #1234; verified the new code paths are covered by inspecting the coverage report."
  - "Performed ad-hoc test by [describe scenario]; observed [result]."
-->
Pulled the branch.
Build the cFS from scratch
Ran the cFS with the change in place
Ran the COSMOS cfs_test_suite
Observed that the test no longer failed when attempting to load the target test tables. 
Confirmed in the /cf/ directory that the tables are now appearing in the directory.
